### PR TITLE
Add [#7] Color Extension 추가

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */; };
 		3C2854FF2B3AA01700369C99 /* ExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FE2B3AA01700369C99 /* ExampleView.swift */; };
 		3C2855012B3AA0A000369C99 /* ExampleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2855002B3AA0A000369C99 /* ExampleCollectionViewCell.swift */; };
+		3C35565B2B494F0A0016BA49 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35565A2B494F0A0016BA49 /* UIColor+.swift */; };
 		3C6192ED2B3A719A00220CEB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6192EC2B3A719A00220CEB /* AppDelegate.swift */; };
 		3C6192EF2B3A719A00220CEB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6192EE2B3A719A00220CEB /* SceneDelegate.swift */; };
 		3C6192F12B3A719A00220CEB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6192F02B3A719A00220CEB /* ViewController.swift */; };
@@ -41,6 +42,7 @@
 		3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
 		3C2854FE2B3AA01700369C99 /* ExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleView.swift; sourceTree = "<group>"; };
 		3C2855002B3AA0A000369C99 /* ExampleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleCollectionViewCell.swift; sourceTree = "<group>"; };
+		3C35565A2B494F0A0016BA49 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		3C6192E92B3A719A00220CEB /* DontBe-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DontBe-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C6192EC2B3A719A00220CEB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3C6192EE2B3A719A00220CEB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				3C6193162B3A7A7B00220CEB /* UIStackView+.swift */,
 				2A6D54C02B479B4300F9891E /* adjusted+.swift */,
 				2A6D54C22B493A8400F9891E /* UIFont+.swift */,
+				3C35565A2B494F0A0016BA49 /* UIColor+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				3C2855012B3AA0A000369C99 /* ExampleCollectionViewCell.swift in Sources */,
 				3C6192EF2B3A719A00220CEB /* SceneDelegate.swift in Sources */,
 				3C2854FF2B3AA01700369C99 /* ExampleView.swift in Sources */,
+				3C35565B2B494F0A0016BA49 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DontBe-iOS/DontBe-iOS/Global/Extension/UIColor+.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Extension/UIColor+.swift
@@ -1,0 +1,92 @@
+//
+//  UIColor+.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/6/24.
+//
+
+import UIKit
+
+extension UIColor {
+    static var donPrimary: UIColor {
+        return UIColor(hex: "#7AEBA8")
+    }
+    
+    static var donSecondary: UIColor {
+        return UIColor(hex: "#ECF6F3")
+    }
+    
+    static var donWhite: UIColor {
+        return UIColor(hex: "#FCFCFD")
+    }
+    
+    static var donBlack: UIColor {
+        return UIColor(hex: "#0E0E0E")
+    }
+    
+    static var donGray1: UIColor {
+        return UIColor(hex: "#F6F6F7")
+    }
+    
+    static var donGray2: UIColor {
+        return UIColor(hex: "#EBEBEE")
+    }
+    
+    static var donGray3: UIColor {
+        return UIColor(hex: "#E1E1E4")
+    }
+    
+    static var donGray4: UIColor {
+        return UIColor(hex: "#D7D7DA")
+    }
+    
+    static var donGray5: UIColor {
+        return UIColor(hex: "#CDCDD0")
+    }
+    
+    static var donGray6: UIColor {
+        return UIColor(hex: "#C2C2C5")
+    }
+    
+    static var donGray7: UIColor {
+        return UIColor(hex: "#B5B5B8")
+    }
+    
+    static var donGray8: UIColor {
+        return UIColor(hex: "#A3A3A6")
+    }
+    
+    static var donGray9: UIColor {
+        return UIColor(hex: "#8F8F92")
+    }
+    
+    static var donGray10: UIColor {
+        return UIColor(hex: "#717174")
+    }
+    
+    static var donGray11: UIColor {
+        return UIColor(hex: "#5D5D60")
+    }
+    
+    static var donGray12: UIColor {
+        return UIColor(hex: "#49494C")
+    }
+}
+
+extension UIColor {
+    convenience init(hex: String, alpha: CGFloat = 1.0) {
+        var hexFormatted: String = hex.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).uppercased()
+
+        if hexFormatted.hasPrefix("#") {
+            hexFormatted = String(hexFormatted.dropFirst())
+        }
+
+        assert(hexFormatted.count == 6, "Invalid hex code used.")
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexFormatted).scanHexInt64(&rgbValue)
+
+        self.init(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
+    }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- UIColor+ 파일 생성
- Color Extension 추가

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- Color Extension은 아래와 같이 hex 값으로 구현했습니다.

https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/b788a765461584f92bb881d95eb86d4d4c7575d5/DontBe-iOS/DontBe-iOS/Global/Extension/UIColor%2B.swift#L10-L74

- 아래는 사용 예시입니다!
~~~
let myName: UILabel = {
     let label = UILabel()
     label.text = "Don't be의 메인 색상!"
     label.textColor = .donPrimary
     return label
 }()
~~~

## 📟 관련 이슈
- Resolved: #7 
