### PR TITLE
[Feat] #38 - 로딩 스피너 구현

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -16,6 +16,7 @@ final class HomeViewController: UIViewController {
     var tabBarHeight: CGFloat = 0
     var showUploadToastView: Bool = false
     private var bottomsheet = HomeBottomsheetView()
+    private let refreshControl = UIRefreshControl()
     
     // MARK: - UI Components
     
@@ -46,6 +47,7 @@ final class HomeViewController: UIViewController {
         setLayout()
         setDelegate()
         setNotification()
+        setRefreshControll()
     }
     
     // MARK: - TabBar Height
@@ -100,6 +102,29 @@ extension HomeViewController {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(showToast(_:)), name: WriteViewController.showUploadToastNotification, object: nil)
     }
+    
+    private func setRefreshControll() {
+        refreshControl.addTarget(self, action: #selector(refreshPost), for: .valueChanged)
+        homeCollectionView.refreshControl = refreshControl
+        refreshControl.backgroundColor = .donGray1
+    }
+    
+    @objc 
+    func refreshPost() {
+        DispatchQueue.main.async {
+            // ✅ 서버 통신 영역
+            //
+        }
+        self.homeCollectionView.reloadData()
+        self.perform(#selector(self.finishedRefreshing), with: nil, afterDelay: 0.1)
+    }
+      
+      @objc 
+    func finishedRefreshing() {
+            refreshControl.endRefreshing()
+      }
+    
+    
     
     @objc func showToast(_ notification: Notification) {
         if let showToast = notification.userInfo?["showToast"] as? Bool {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- UIRefreshControl을 사용해 홈 뷰에서 pull down 시 로딩 스피너가 나오도록 구현했습니다.
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/c2b13b7564b67d35f0c88d004cf313f7753b896f/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift#L106-L125
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/cb90bb3b-0007-4983-9e51-0b6c470baa1d" width ="250">|

## 📟 관련 이슈
- Resolved: #38 
