### PR TITLE
Feat [#47] 수정 사항 반영 및 알림뷰 뷰컨 뷰모델 분리

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Global/Extension/Publisher+UIControl.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Extension/Publisher+UIControl.swift
@@ -18,6 +18,12 @@ public extension CombineCompatible where Self: UIControl {
     }
 }
 
+public extension CombineCompatible where Self: UIRefreshControl {
+    var refreshControlPublisher: UIControlPublisher<Self> {
+        return UIControlPublisher(control: self, events: .valueChanged)
+    }
+}
+
 final class UIControlSubscription<SubscriberType: Subscriber, Control: UIControl>: Subscription where SubscriberType.Input == Control {
     private var subscriber: SubscriberType?
     private let control: Control

--- a/DontBe-iOS/DontBe-iOS/Global/Extension/UIView+.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Extension/UIView+.swift
@@ -13,9 +13,17 @@ extension UIView {
             self.addSubview($0)
         }
     }
+    
     func makeDivisionLine() -> UIView {
         let divisionLine = UIView()
         divisionLine.backgroundColor = .donGray2
         return divisionLine
     }
+    
+    func isValidInput(_ input: String) -> Bool {
+        let regex = try! NSRegularExpression(pattern: "^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z_0-9]+$", options: .caseInsensitive)
+        let matches = regex.matches(in: input, options: [], range: NSRange(location: 0, length: input.utf16.count))
+        return matches.count > 0
+    }
 }
+

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/ImageLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/ImageLiterals.swift
@@ -50,7 +50,7 @@ enum ImageLiterals {
     enum Join {
         static var btnCheckBox: UIImage { .load(name: "btn_checkbox") }
         static var btnNotCheckBox: UIImage { .load(name: "btn_not_checkbox") }
-        static var btnNecessary: UIImage { .load(name: "btn_necessary") }
+        static var imgNecessary: UIImage { .load(name: "btn_necessary") }
         static var btnSelect: UIImage { .load(name: "btn_select") }
         static var btnView: UIImage { .load(name: "btn_view") }
         static var btnPlus: UIImage { .load(name: "btn_plus") }

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -40,6 +40,7 @@ enum StringLiterals {
         static let advertisementAgreement = "마케팅 활용 / 광고성 정보 수신동의"
         static let nickName = "닉네임"
         static let nickNamePlaceHolder = "닉네임을 입력해주세요."
+        static let notValidNickName = "*닉네임에 사용할 수 없는 문자가 포함되어 있어요."
         static let duplicationCheck = "중복확인"
         static let duplicationCheckDescription = "*중복된 닉네임인지 확인해주세요"
         static let duplicationNotPass = "*사용 불가능한 닉네임입니다."

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinAgreementViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinAgreementViewController.swift
@@ -4,7 +4,9 @@
 //
 //  Created by 변희주 on 1/10/24.
 //
+
 import Combine
+import SafariServices
 import UIKit
 
 import SnapKit

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinAgreementViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinAgreementViewController.swift
@@ -15,6 +15,8 @@ final class JoinAgreementViewController: UIViewController {
     
     // MARK: - Properties
     
+    let useAgreementURL = NSURL(string: "https://joyous-ghost-8c7.notion.site/4ac9966cf7d944bf9595352edbc1b1b0")
+    
     private var cancelBag = CancelBag()
     private let viewModel: JoinAgreeViewModel
     
@@ -25,7 +27,6 @@ final class JoinAgreementViewController: UIViewController {
     private lazy var thirdCheck = self.originView.thirdCheckView.checkButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
     private lazy var fourtchCheck = self.originView.fourthCheckView.checkButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
     private lazy var nextButtonTapped = self.originView.nextActiveButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
-    
     
     // MARK: - UI Components
     
@@ -53,15 +54,14 @@ final class JoinAgreementViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUI()
+        setAddTarget()
         bindViewModel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        self.navigationController?.navigationBar.isHidden = false
-        self.navigationItem.hidesBackButton = true
+        setUI()
         setHierarchy()
         setLayout()
     }
@@ -73,6 +73,8 @@ extension JoinAgreementViewController {
     private func setUI() {
         self.view.backgroundColor = .donGray1
         self.navigationItem.title = StringLiterals.Join.joinNavigationTitle
+        self.navigationController?.navigationBar.isHidden = false
+        self.navigationItem.hidesBackButton = true
     }
     
     private func setHierarchy() {
@@ -84,6 +86,10 @@ extension JoinAgreementViewController {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().inset(23.adjusted)
         }
+    }
+    
+    private func setAddTarget() {
+        self.originView.firstCheckView.moreButton.addTarget(self, action: #selector(moreButtonTapped), for: .touchUpInside)
     }
     
     private func bindViewModel() {
@@ -169,5 +175,16 @@ extension JoinAgreementViewController {
                 self.navigationController?.pushViewController(viewController, animated: true)
             }
             .store(in: self.cancelBag)
+    }
+    
+    @objc
+    private func moreButtonTapped() {
+        let useAgreementView: SFSafariViewController
+        if let useAgreementURL = self.useAgreementURL as? URL {
+            useAgreementView = SFSafariViewController(url: useAgreementURL)
+            self.present(useAgreementView, animated: true, completion: nil)
+        } else {
+            print("👻👻👻 유효하지 않은 URL 입니다 👻👻👻")
+        }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinAgreeViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinAgreeViewModel.swift
@@ -51,13 +51,23 @@ final class JoinAgreeViewModel: ViewModelType {
         input.allCheckButtonTapped
             .sink { [weak self] _ in
                 // 모든 버튼 상태를 업데이트하고 신호를 보냄
-                self?.isAllChecked.toggle()
-                self?.isFirstChecked = self?.isAllChecked ?? false
-                self?.isSecondChecked = self?.isAllChecked ?? false
-                self?.isThirdChecked = self?.isAllChecked ?? false
-                self?.isFourthChecked = self?.isAllChecked ?? false
-                self?.isEnabled.send(self?.isNextButtonEnabled() ?? 0)
-                self?.allButtonChecked.send(self?.isAllChecked ?? false)
+                if self?.isFirstChecked == true && self?.isSecondChecked == true && self?.isThirdChecked == true && self?.isFourthChecked == true {
+                    self?.isAllChecked.toggle()
+                    self?.isFirstChecked = self?.isAllChecked ?? false
+                    self?.isSecondChecked = self?.isAllChecked ?? false
+                    self?.isThirdChecked = self?.isAllChecked ?? false
+                    self?.isFourthChecked = self?.isAllChecked ?? false
+                    self?.isEnabled.send(self?.isNextButtonEnabled() ?? 0)
+                    self?.allButtonChecked.send(self?.isAllChecked ?? false)
+                } else {
+                    self?.isAllChecked = true
+                    self?.isFirstChecked = self?.isAllChecked ?? false
+                    self?.isSecondChecked = self?.isAllChecked ?? false
+                    self?.isThirdChecked = self?.isAllChecked ?? false
+                    self?.isFourthChecked = self?.isAllChecked ?? false
+                    self?.isEnabled.send(self?.isNextButtonEnabled() ?? 0)
+                    self?.allButtonChecked.send(self?.isAllChecked ?? false)
+                }
             }
             .store(in: cancelBag)
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinAgreeViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinAgreeViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 
 final class JoinAgreeViewModel: ViewModelType {
+   
     private let cancelBag = CancelBag()
     
     private let popViewController = PassthroughSubject<Void, Never>()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 
 final class JoinProfileViewModel: ViewModelType {
+    
     private let cancelBag = CancelBag()
     private let pushOrPopViewController = PassthroughSubject<Int, Never>()
     private let isNotDuplicated = PassthroughSubject<Bool, Never>()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/AgreementListCustomView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/AgreementListCustomView.swift
@@ -24,15 +24,9 @@ final class AgreementListCustomView: UIView {
         return infoLabel
     }()
     
-    let necessaryOrSelectButton: UIButton = {
-        let necessaryOrSelectButton = UIButton()
-        return necessaryOrSelectButton
-    }()
+    let necessaryOrSelectImage = UIImageView()
     
-    let moreButton: UIButton = {
-        let moreButton = UIButton()
-        return moreButton
-    }()
+    let moreButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -42,12 +36,12 @@ final class AgreementListCustomView: UIView {
         super.init(frame: .zero)
         
         infoLabel.text = title
-        necessaryOrSelectButton.setImage(subImage, for: .normal)
+        necessaryOrSelectImage.image = subImage
         moreButton.setImage(moreImage, for: .normal)
         
         self.addSubviews(checkButton,
                          infoLabel,
-                         necessaryOrSelectButton,
+                         necessaryOrSelectImage,
                          moreButton)
         
         checkButton.snp.makeConstraints {
@@ -60,7 +54,7 @@ final class AgreementListCustomView: UIView {
             $0.centerY.equalTo(checkButton)
         }
         
-        necessaryOrSelectButton.snp.makeConstraints {
+        necessaryOrSelectImage.snp.makeConstraints {
             $0.leading.equalTo(infoLabel.snp.trailing).offset(4.adjusted)
             $0.centerY.equalTo(infoLabel)
             $0.width.equalTo(33.adjusted)
@@ -68,7 +62,7 @@ final class AgreementListCustomView: UIView {
         }
         
         moreButton.snp.makeConstraints {
-            $0.leading.equalTo(necessaryOrSelectButton.snp.trailing).offset(6.adjusted)
+            $0.leading.equalTo(necessaryOrSelectImage.snp.trailing).offset(6.adjusted)
             $0.centerY.equalTo(infoLabel)
             $0.width.equalTo(23.adjusted)
             $0.height.equalTo(24.adjusted)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinAgreeView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinAgreeView.swift
@@ -38,9 +38,9 @@ final class JoinAgreeView: UIView {
     }()
     
     let allCheck = AgreementListCustomView(title: StringLiterals.Join.allCheck, subImage: nil, moreImage: nil)
-    let firstCheckView = AgreementListCustomView(title: StringLiterals.Join.useAgreement, subImage: ImageLiterals.Join.btnNecessary)
-    let secondCheckView = AgreementListCustomView(title: StringLiterals.Join.privacyAgreement, subImage: ImageLiterals.Join.btnNecessary)
-    let thirdCheckView = AgreementListCustomView(title: StringLiterals.Join.checkAge, subImage: ImageLiterals.Join.btnNecessary, moreImage: nil)
+    let firstCheckView = AgreementListCustomView(title: StringLiterals.Join.useAgreement, subImage: ImageLiterals.Join.imgNecessary)
+    let secondCheckView = AgreementListCustomView(title: StringLiterals.Join.privacyAgreement, subImage: ImageLiterals.Join.imgNecessary)
+    let thirdCheckView = AgreementListCustomView(title: StringLiterals.Join.checkAge, subImage: ImageLiterals.Join.imgNecessary, moreImage: nil)
     let fourthCheckView = AgreementListCustomView(title: StringLiterals.Join.advertisementAgreement, subImage: ImageLiterals.Join.btnSelect)
     
     private let nextButton: UIButton = {
@@ -74,11 +74,11 @@ final class JoinAgreeView: UIView {
 // MARK: - Extensions
 
 extension JoinAgreeView {
-    func setUI() {
+    private func setUI() {
         allCheck.infoLabel.font = .font(.body1)
     }
     
-    func setHierarchy() {
+    private func setHierarchy() {
         self.addSubviews(topDivisionLine,
                          titleLabel,
                          descriptionLabel,
@@ -92,7 +92,7 @@ extension JoinAgreeView {
                          nextActiveButton)
     }
     
-    func setLayout() {
+    private func setLayout() {
         topDivisionLine.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(self.safeAreaLayoutGuide)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinAgreeView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinAgreeView.swift
@@ -40,7 +40,7 @@ final class JoinAgreeView: UIView {
     let allCheck = AgreementListCustomView(title: StringLiterals.Join.allCheck, subImage: nil, moreImage: nil)
     let firstCheckView = AgreementListCustomView(title: StringLiterals.Join.useAgreement, subImage: ImageLiterals.Join.btnNecessary)
     let secondCheckView = AgreementListCustomView(title: StringLiterals.Join.privacyAgreement, subImage: ImageLiterals.Join.btnNecessary)
-    let thirdCheckView = AgreementListCustomView(title: StringLiterals.Join.checkAge, subImage: ImageLiterals.Join.btnNecessary)
+    let thirdCheckView = AgreementListCustomView(title: StringLiterals.Join.checkAge, subImage: ImageLiterals.Join.btnNecessary, moreImage: nil)
     let fourthCheckView = AgreementListCustomView(title: StringLiterals.Join.advertisementAgreement, subImage: ImageLiterals.Join.btnSelect)
     
     private let nextButton: UIButton = {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinProfileView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinProfileView.swift
@@ -63,11 +63,12 @@ final class JoinProfileView: UIView {
     let duplicationCheckButton: UIButton = {
         let duplicationCheckButton = UIButton()
         duplicationCheckButton.setTitle(StringLiterals.Join.duplicationCheck, for: .normal)
-        duplicationCheckButton.setTitleColor(.donBlack, for: .normal)
+        duplicationCheckButton.setTitleColor(.donGray9, for: .normal)
+        duplicationCheckButton.backgroundColor = .donGray4
         duplicationCheckButton.titleLabel?.font = .font(.body3)
         duplicationCheckButton.layer.cornerRadius = 4.adjusted
         duplicationCheckButton.layer.masksToBounds = true
-        duplicationCheckButton.backgroundColor = .donPrimary
+        duplicationCheckButton.isEnabled = false
         return duplicationCheckButton
     }()
     
@@ -77,6 +78,15 @@ final class JoinProfileView: UIView {
         duplicationCheckDescription.textColor = .donGray8
         duplicationCheckDescription.font = .font(.caption4)
         return duplicationCheckDescription
+    }()
+    
+    let isNotValidNickname: UILabel = {
+        let isNotValidNickname = UILabel()
+        isNotValidNickname.text = StringLiterals.Join.notValidNickName
+        isNotValidNickname.textColor = .donError
+        isNotValidNickname.font = .font(.caption4)
+        isNotValidNickname.isHidden = true
+        return isNotValidNickname
     }()
     
     let finishButton: UIButton = {
@@ -118,6 +128,7 @@ extension JoinProfileView {
                          nickNameTextField,
                          duplicationCheckButton,
                          duplicationCheckDescription,
+                         isNotValidNickname,
                          finishButton,
                          finishActiveButton)
         
@@ -169,6 +180,10 @@ extension JoinProfileView {
         duplicationCheckDescription.snp.makeConstraints {
             $0.top.equalTo(nickNameTextField.snp.bottom).offset(6.adjustedH)
             $0.leading.equalToSuperview().inset(16.adjusted)
+        }
+        
+        isNotValidNickname.snp.makeConstraints {
+            $0.top.leading.equalTo(duplicationCheckDescription)
         }
         
         finishButton.snp.makeConstraints {
@@ -226,6 +241,7 @@ extension JoinProfileView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         let text = textField.text ?? "" // textField에 수정이 반영된 후의 text
         let maxLength = 12 // 글자 수 제한
+        
         if text.count >= maxLength {
             let startIndex = text.startIndex
             let endIndex = text.index(startIndex, offsetBy: maxLength - 1)
@@ -235,5 +251,18 @@ extension JoinProfileView: UITextFieldDelegate {
         } else {
             self.numOfLetters.text = "(\(text.count)/\(maxLength))"
         }
+
+        if isValidInput(text) {
+            duplicationCheckButton.isEnabled = true
+            duplicationCheckButton.setTitleColor(.donBlack, for: .normal)
+            duplicationCheckButton.backgroundColor = .donPrimary
+        } else {
+            duplicationCheckButton.isEnabled = false
+            duplicationCheckButton.setTitleColor(.donGray9, for: .normal)
+            duplicationCheckButton.backgroundColor = .donGray4
+        }
+        
+        duplicationCheckDescription.isHidden = !isValidInput(text)
+        isNotValidNickname.isHidden = isValidInput(text)
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -12,6 +12,7 @@ import KakaoSDKUser
 import KakaoSDKCommon
 
 final class LoginViewModel: ViewModelType {
+    
     private let cancelBag = CancelBag()
     
     struct Input {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
@@ -79,6 +79,15 @@ final class MyPageNicknameEditView: UIView {
         return duplicationCheckDescription
     }()
     
+    let isNotValidNickname: UILabel = {
+        let isNotValidNickname = UILabel()
+        isNotValidNickname.text = StringLiterals.Join.notValidNickName
+        isNotValidNickname.textColor = .donError
+        isNotValidNickname.font = .font(.caption4)
+        isNotValidNickname.isHidden = true
+        return isNotValidNickname
+    }()
+    
     // MARK: - Life Cycles
     
     override init(frame: CGRect) {
@@ -105,7 +114,8 @@ extension MyPageNicknameEditView {
                          nickNameLabel,
                          nickNameTextField,
                          duplicationCheckButton,
-                         duplicationCheckDescription)
+                         duplicationCheckDescription,
+                         isNotValidNickname)
         
         nickNameTextField.addSubview(numOfLetters)
     }
@@ -155,6 +165,10 @@ extension MyPageNicknameEditView {
         duplicationCheckDescription.snp.makeConstraints {
             $0.top.equalTo(nickNameTextField.snp.bottom).offset(6.adjustedH)
             $0.leading.equalToSuperview().inset(16.adjusted)
+        }
+        
+        isNotValidNickname.snp.makeConstraints {
+            $0.top.leading.equalTo(duplicationCheckDescription)
         }
     }
     
@@ -215,5 +229,18 @@ extension MyPageNicknameEditView: UITextFieldDelegate {
         } else {
             self.numOfLetters.text = "(\(text.count)/\(maxLength))"
         }
+        
+        if isValidInput(text) {
+            duplicationCheckButton.isEnabled = true
+            duplicationCheckButton.setTitleColor(.donBlack, for: .normal)
+            duplicationCheckButton.backgroundColor = .donPrimary
+        } else {
+            duplicationCheckButton.isEnabled = false
+            duplicationCheckButton.setTitleColor(.donGray9, for: .normal)
+            duplicationCheckButton.backgroundColor = .donGray4
+        }
+        
+        duplicationCheckDescription.isHidden = !isValidInput(text)
+        isNotValidNickname.isHidden = isValidInput(text)
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/Cells/NotificationTableViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/Cells/NotificationTableViewCell.swift
@@ -93,7 +93,7 @@ extension NotificationTableViewCell {
     }
     
     func configureCell(item: NotificationDummy) {
-        profileImage.setCircularImage(image: item.profile)
+        profileImage.setCircularImage(image: item.profile ?? UIImage())
         notificationLabel.text = item.userName + " " + item.description
         if item.description == StringLiterals.Notification.violation {
             notificationLabel.setTextWithLineHeightAndFont(

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/Helpers/NotificationDummy.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/Helpers/NotificationDummy.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 struct NotificationDummy {
-    let profile: UIImage
+    let profile: UIImage?
     let userName: String
     let description: String
     let minutes: String

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewControllers/NotificationViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewControllers/NotificationViewController.swift
@@ -108,7 +108,7 @@ extension NotificationViewController {
     }
     
     private func bindViewModel() {
-        let input = NotificationViewModel.Input(viewAppear: Just(()).eraseToAnyPublisher(), refreshControlClicked: refreshControlClicked)
+        let input = NotificationViewModel.Input(viewLoad: Just(()).eraseToAnyPublisher(), refreshControlClicked: refreshControlClicked)
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewModels/NotificationViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewModels/NotificationViewModel.swift
@@ -5,4 +5,23 @@
 //  Created by 변희주 on 1/12/24.
 //
 
+import Combine
 import Foundation
+
+final class NotificationViewModel {
+    
+    private let reloadTableView = PassthroughSubject<[NotificationDummy], Never>()
+    let dummy = NotificationDummy.dummy()
+    
+    struct Output {
+        let reloadTableView: PassthroughSubject<[NotificationDummy], Never>
+    }
+    
+    func transform() -> Output {
+        // 서버통신으로 구조체 받아옴
+        // self.dummy는 서버통신으로 받아온 구조체 배열로 대체
+        self.reloadTableView.send(self.dummy)
+      
+        return Output(reloadTableView: reloadTableView)
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewModels/NotificationViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewModels/NotificationViewModel.swift
@@ -15,7 +15,7 @@ final class NotificationViewModel: ViewModelType {
     var dummy = [NotificationDummy(profile: nil, userName: "", description: "", minutes: "")]
     
     struct Input {
-        let viewAppear: AnyPublisher<Void, Never>
+        let viewLoad: AnyPublisher<Void, Never>
         let refreshControlClicked: AnyPublisher<Void, Never>
     }
     
@@ -26,7 +26,7 @@ final class NotificationViewModel: ViewModelType {
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
         // 서버통신으로 구조체 받아옴
         // self.dummy는 서버통신으로 받아온 구조체 배열로 대체
-        input.viewAppear
+        input.viewLoad
             .sink { _ in
                 self.dummy = NotificationDummy.dummy()
                 self.reloadTableView.send(0)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewModels/OnboardingEndingViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewModels/OnboardingEndingViewModel.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 
 final class OnboardingEndingViewModel: ViewModelType {
+    
     private let cancelBag = CancelBag()
     
     struct Input {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/Views/OnboardingView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/Views/OnboardingView.swift
@@ -149,6 +149,8 @@ extension OnboardingView {
                     $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(29.adjusted)
                     $0.centerX.equalToSuperview()
                 }
+                
+                self.skipButton.removeFromSuperview()
             }
         }
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarItem.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarItem.swift
@@ -44,7 +44,7 @@ enum DontBeTabBarItem: CaseIterable {
         switch self {
         case .home: return HomeViewController()
         case .writing: return nil // 애니메이션 -> 다른 곳에서 뷰컨 연결
-        case .notification: return NotificationViewController()
+        case .notification: return NotificationViewController(viewModel: NotificationViewModel())
         case .myPage: return MyPageViewController()
         }
     }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
 - 회원가입 웹 뷰 연결 및 버튼 수정
 - 닉네임 정규식 추가
 - 알림뷰 뷰컨 뷰모델 분리
 
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- NotificationViewModel에서 데이터에 관련된 로직을 처리해주는 방식으로 코드를 수정했습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/e161243c792c8dd2df3898b224a6a8550845275f/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewModels/NotificationViewModel.swift#L11-L47
- UIRefreshControl의 이벤트를 Combine publisher로 변환해주었습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/e161243c792c8dd2df3898b224a6a8550845275f/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewControllers/NotificationViewController.swift#L25-L26
- Just(()).eraseToAnyPublisher()를 통해 뷰가 처음 로드되었을 때 한 번만 신호를 전달하였습니다.
~~~
let input = NotificationViewModel.Input(viewAppear: Just(()).eraseToAnyPublisher(), refreshControlClicked: refreshControlClicked)
~~~
## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|회원가입 14세이상 <br>자세히 보기 <br>버튼 수정|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/726e3645-e34f-4000-9efd-f3366422a133" width ="250">|이용약관 <br> 웹뷰 연결|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/05dc2f1e-3134-4dc5-95b7-18355e4b26aa" width="250">|
| 닉네임 <br> 정규식 추가 |<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/731038db-0a96-4370-807b-738723780310" width ="250">| 닉네임 <br> 정규식 추가 |<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/7430f7e8-bba9-4d3e-b97e-b03479f8bd32" width ="250">|
## 📟 관련 이슈
- Resolved: #47 
