### PR TITLE
Feat [#51] 답글 작성 뷰 구현

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -59,12 +59,17 @@
 		2F8735462B4C34A500E55552 /* HomeCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8735452B4C34A500E55552 /* HomeCollectionView.swift */; };
 		2F8735482B4C355100E55552 /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8735472B4C355100E55552 /* HomeCollectionViewCell.swift */; };
 		2F87354C2B4D28D700E55552 /* HomeCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F87354B2B4D28D700E55552 /* HomeCollectionFooterView.swift */; };
+		2FB64FF02B5310DD0082A414 /* WriteReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB64FEF2B5310DD0082A414 /* WriteReplyViewController.swift */; };
+		2FB64FF22B5318C50082A414 /* WriteReplyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB64FF12B5318C50082A414 /* WriteReplyPostView.swift */; };
+		2FB64FF42B531A5C0082A414 /* WriteReplyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB64FF32B531A5C0082A414 /* WriteReplyView.swift */; };
+		2FB64FF62B531E4F0082A414 /* WriteReplyEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB64FF52B531E4F0082A414 /* WriteReplyEditorView.swift */; };
 		2FB769D02B5277BD004C7752 /* PostReplyTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB769CF2B5277BD004C7752 /* PostReplyTextFieldView.swift */; };
 		2FB818D12B51693400B7498F /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818D02B51693400B7498F /* PostViewController.swift */; };
 		2FB818D32B51694F00B7498F /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818D22B51694F00B7498F /* PostView.swift */; };
 		2FB818D52B517EE700B7498F /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818D42B517EE700B7498F /* PostDetailView.swift */; };
 		2FB818D92B5186FC00B7498F /* PostReplyCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */; };
 		2FB818DC2B51875D00B7498F /* PostReplyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */; };
+		2FBBADF12B53AF9B002D6286 /* PostReplyCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */; };
 		3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */; };
 		3C0920DE2B4D98CD003BD080 /* DontBeToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */; };
 		3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */; };
@@ -153,12 +158,17 @@
 		2F8735452B4C34A500E55552 /* HomeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionView.swift; sourceTree = "<group>"; };
 		2F8735472B4C355100E55552 /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		2F87354B2B4D28D700E55552 /* HomeCollectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionFooterView.swift; sourceTree = "<group>"; };
+		2FB64FEF2B5310DD0082A414 /* WriteReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReplyViewController.swift; sourceTree = "<group>"; };
+		2FB64FF12B5318C50082A414 /* WriteReplyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReplyPostView.swift; sourceTree = "<group>"; };
+		2FB64FF32B531A5C0082A414 /* WriteReplyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReplyView.swift; sourceTree = "<group>"; };
+		2FB64FF52B531E4F0082A414 /* WriteReplyEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteReplyEditorView.swift; sourceTree = "<group>"; };
 		2FB769CF2B5277BD004C7752 /* PostReplyTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyTextFieldView.swift; sourceTree = "<group>"; };
 		2FB818D02B51693400B7498F /* PostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostViewController.swift; path = "DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift"; sourceTree = SOURCE_ROOT; };
 		2FB818D22B51694F00B7498F /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
 		2FB818D42B517EE700B7498F /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionView.swift; sourceTree = "<group>"; };
 		2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionViewCell.swift; sourceTree = "<group>"; };
+		2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionFooterView.swift; sourceTree = "<group>"; };
 		3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBePopupView.swift; sourceTree = "<group>"; };
 		3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeToastView.swift; sourceTree = "<group>"; };
 		3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
@@ -409,6 +419,7 @@
 		2FB818CE2B5168D400B7498F /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				2FB64FEF2B5310DD0082A414 /* WriteReplyViewController.swift */,
 				2FB818D02B51693400B7498F /* PostViewController.swift */,
 			);
 			path = ViewControllers;
@@ -420,7 +431,11 @@
 				2FB818D42B517EE700B7498F /* PostDetailView.swift */,
 				2FB818D22B51694F00B7498F /* PostView.swift */,
 				2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */,
+				2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */,
 				2FB769CF2B5277BD004C7752 /* PostReplyTextFieldView.swift */,
+				2FB64FF32B531A5C0082A414 /* WriteReplyView.swift */,
+				2FB64FF12B5318C50082A414 /* WriteReplyPostView.swift */,
+				2FB64FF52B531E4F0082A414 /* WriteReplyEditorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -808,6 +823,7 @@
 				2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */,
 				3C2F544E2B50F65500E7BF01 /* DontBeBottomSheetView.swift in Sources */,
 				3C61930C2B3A782100220CEB /* StringLiterals.swift in Sources */,
+				2FB64FF22B5318C50082A414 /* WriteReplyPostView.swift in Sources */,
 				2FB818D52B517EE700B7498F /* PostDetailView.swift in Sources */,
 				2F8735462B4C34A500E55552 /* HomeCollectionView.swift in Sources */,
 				3CEE4CBD2B500A7800F506AF /* DontBeTransparencyInfoView.swift in Sources */,
@@ -820,6 +836,7 @@
 				3C2F54522B51224500E7BF01 /* MyPageAccountInfoViewController.swift in Sources */,
 				3CE9C1352B4C4BC20086E4A3 /* CircleProgressbar.swift in Sources */,
 				2AF069B22B518F8E00CA3E48 /* MyPageNicknameEditView.swift in Sources */,
+				2FB64FF42B531A5C0082A414 /* WriteReplyView.swift in Sources */,
 				3C6193192B3A7AC700220CEB /* Config.swift in Sources */,
 				3CF184D12B4EFF9900816D5F /* MyPageProfileView.swift in Sources */,
 				3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */,
@@ -862,6 +879,8 @@
 				2A8D70D32B4DD360009F4C6C /* JoinAgreeViewModel.swift in Sources */,
 				3C2855012B3AA0A000369C99 /* ExampleCollectionViewCell.swift in Sources */,
 				3C2F54542B5126C600E7BF01 /* UIBarButtonItem+.swift in Sources */,
+				2FBBADF12B53AF9B002D6286 /* PostReplyCollectionFooterView.swift in Sources */,
+				2FB64FF62B531E4F0082A414 /* WriteReplyEditorView.swift in Sources */,
 				2FB769D02B5277BD004C7752 /* PostReplyTextFieldView.swift in Sources */,
 				2A2671FD2B4C3A9F009D214F /* LoginViewModel.swift in Sources */,
 				2FB818DC2B51875D00B7498F /* PostReplyCollectionViewCell.swift in Sources */,
@@ -881,6 +900,7 @@
 				2AF069AE2B514B0100CA3E48 /* NotificationEmptyViewCell.swift in Sources */,
 				2AC9FB1B2B4DE77400D31071 /* AgreementListCustomView.swift in Sources */,
 				2F17418A2B500CC20089FC4D /* HomeBottomsheetView.swift in Sources */,
+				2FB64FF02B5310DD0082A414 /* WriteReplyViewController.swift in Sources */,
 				3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */,
 				2A2671FF2B4C3AF0009D214F /* Publisher+UIControl.swift in Sources */,
 				3C4993672B4F2644002A99CF /* MyPageContentViewController.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -81,13 +81,13 @@ extension HomeViewController {
     private func setLayout() {
         homeCollectionView.snp.makeConstraints {
             $0.top.equalTo(myView.safeAreaLayoutGuide.snp.top).offset(52.adjusted)
-            $0.bottom.equalTo(tabBarHeight)
+            $0.bottom.equalTo(tabBarHeight.adjusted)
             $0.width.equalToSuperview()
         }
         
         uploadToastView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16.adjusted)
-            $0.bottom.equalTo(tabBarHeight).inset(6.adjusted)
+            $0.bottom.equalTo(tabBarHeight.adjusted).inset(6.adjusted)
             $0.height.equalTo(44)
         }
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
@@ -179,7 +179,7 @@ extension PostReplyCollectionViewCell {
             $0.top.bottom.equalToSuperview()
             $0.leading.equalToSuperview().inset(14.adjusted)
             $0.trailing.equalToSuperview()
-            $0.width.equalTo(UIScreen.main.bounds.width - 56.adjusted)
+            $0.width.equalTo(UIScreen.main.bounds.width - 64.adjusted)
         }
         
         horizontalCellBarView.snp.makeConstraints {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -74,7 +74,8 @@ extension PostViewController {
     private func setUI() {
         self.navigationItem.title = StringLiterals.Post.navigationTitleLabel
         textFieldView.replyTextFieldLabel.text = (postUserNickname ?? "") + StringLiterals.Post.textFieldLabel
-        self.view.backgroundColor = .donGray1
+        
+        self.view.backgroundColor = .donWhite
     }
     
     private func setHierarchy() {
@@ -105,7 +106,7 @@ extension PostViewController {
         }
         
         textFieldView.snp.makeConstraints {
-            $0.bottom.equalTo(tabBarHeight)
+            $0.bottom.equalTo(tabBarHeight.adjusted)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56.adjusted)
         }
@@ -129,7 +130,12 @@ extension PostViewController {
     }
     
     @objc func textFieldDidTapped() {
-
+        showReplyVC()
+    }
+    
+    private func showReplyVC() {
+        let navigationController = UINavigationController(rootViewController: WriteReplyViewController())
+        present(navigationController, animated: true, completion: nil)
     }
 }
 
@@ -156,7 +162,13 @@ extension PostViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        guard let footer = postReplyCollectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "HomeCollectionFooterView", for: indexPath) as? HomeCollectionFooterView else { return UICollectionReusableView() }
+        guard let footer = postReplyCollectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "PostReplyCollectionFooterView", for: indexPath) as? PostReplyCollectionFooterView else { return UICollectionReusableView() }
+        footer.backgroundColor = .red
         return footer
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+        
+        return CGSize(width: UIScreen.main.bounds.width, height: 24.adjusted)
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -12,13 +12,15 @@ final class PostViewController: UIViewController {
     // MARK: - Properties
     var tabBarHeight: CGFloat = 0
     private lazy var postUserNickname = postView.postNicknameLabel.text
+    private lazy var postDividerView = postView.horizontalDivierView
     
     // MARK: - UI Components
     
     private lazy var myView = PostDetailView()
     private lazy var postView = PostView()
-    private lazy var textFieldview = PostReplyTextFieldView()
+    private lazy var textFieldView = PostReplyTextFieldView()
     private lazy var postReplyCollectionView = PostReplyCollectionView().collectionView
+    private lazy var greenTextField = textFieldView.greenTextFieldView
     
     private let verticalBarView: UIView = {
         let view = UIView()
@@ -33,6 +35,7 @@ final class PostViewController: UIViewController {
         
         view = myView
         self.navigationController?.navigationBar.isHidden = false
+        textFieldView.isUserInteractionEnabled = true
     }
     
     override func viewDidLoad() {
@@ -43,6 +46,8 @@ final class PostViewController: UIViewController {
         setHierarchy()
         setLayout()
         setDelegate()
+        setTextFieldGesture()
+        
     }
     
     // MARK: - TabBar Height
@@ -68,40 +73,41 @@ final class PostViewController: UIViewController {
 extension PostViewController {
     private func setUI() {
         self.navigationItem.title = StringLiterals.Post.navigationTitleLabel
-        textFieldview.replyTextFieldLabel.text = (postUserNickname ?? "") + StringLiterals.Post.textFieldLabel
+        textFieldView.replyTextFieldLabel.text = (postUserNickname ?? "") + StringLiterals.Post.textFieldLabel
+        self.view.backgroundColor = .donGray1
     }
     
     private func setHierarchy() {
         view.addSubviews(postView,
                          verticalBarView,
                          postReplyCollectionView,
-                         textFieldview)
+                         textFieldView)
     }
     
     private func setLayout() {
         postView.snp.makeConstraints {
             $0.top.equalTo(self.view.safeAreaLayoutGuide)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
         }
         
         postReplyCollectionView.snp.makeConstraints {
-            $0.top.equalTo(postView.PostbackgroundUIView.snp.bottom).offset(10.adjusted)
-            $0.bottom.equalTo(tabBarHeight).inset(66)
+            $0.top.equalTo(postView.horizontalDivierView.snp.bottom).offset(10)
+            $0.bottom.equalTo(textFieldView.snp.bottom).offset(-56.adjusted)
             $0.leading.equalTo(verticalBarView.snp.trailing)
             $0.trailing.equalToSuperview().inset(16.adjusted)
         }
         
         verticalBarView.snp.makeConstraints {
-            $0.top.equalTo(postView.horizontalDivierView.snp.bottom)
-            $0.leading.equalToSuperview().inset(18.adjusted)
+            $0.top.equalTo(postReplyCollectionView)
+            $0.leading.equalToSuperview().inset(16.adjusted)
             $0.width.equalTo(1.adjusted)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(postReplyCollectionView.snp.bottom)
         }
         
-        textFieldview.snp.makeConstraints {
-            $0.bottom.equalTo(tabBarHeight).offset(-56)
+        textFieldView.snp.makeConstraints {
+            $0.bottom.equalTo(tabBarHeight)
             $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(56.adjusted)
         }
     }
     
@@ -113,6 +119,17 @@ extension PostViewController {
     @objc
     private func backButtonPressed() {
         self.navigationController?.popViewController(animated: true)
+    }
+    
+    private func setTextFieldGesture() {
+        greenTextField.isUserInteractionEnabled = true
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(textFieldDidTapped))
+        gesture.cancelsTouchesInView = false
+        greenTextField.addGestureRecognizer(gesture)
+    }
+    
+    @objc func textFieldDidTapped() {
+
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -1,0 +1,104 @@
+//
+//  WriteReplyViewController.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+final class WriteReplyViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let myView = WriteReplyView()
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = myView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        getAPI()
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+        setBottomSheet()
+        setNavigationBarButtonItem()
+    }
+}
+
+// MARK: - Extensions
+
+extension WriteReplyViewController {
+    private func setUI() {
+        myView.backgroundColor = .donWhite
+        title = "답글달기"
+    }
+    
+    private func setHierarchy() {
+        
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    private func setDelegate() {
+        
+    }
+    
+    private func setBottomSheet() {
+        /// 밑으로 내려도 dismiss되지 않는 옵션 값
+        isModalInPresentation = true
+        
+        if let sheet = sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.selectedDetentIdentifier = .large
+            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = true
+            sheet.prefersGrabberVisible = false
+        }
+    }
+    
+    private func setNavigationBarButtonItem() {
+        let cancelButton = UIBarButtonItem(title: "취소", primaryAction: .init(handler: { [weak self] _Arg in
+            self?.dismiss(animated: true)
+        }))
+        navigationItem.leftBarButtonItem = cancelButton
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.donGray11,
+            .font: UIFont.font(.caption4)
+            ]
+        cancelButton.setTitleTextAttributes(attributes, for: .normal)
+        cancelButton.setTitleTextAttributes(attributes, for: .highlighted)
+    }
+}
+
+// MARK: - Network
+
+extension WriteReplyViewController {
+    private func getAPI() {
+        
+    }
+}
+
+//extension ExampleViewController: UICollectionViewDelegate {
+//
+//}
+//
+//extension ExampleViewController: UICollectionViewDataSource {
+//
+//}
+//
+//extension ExampleViewController: UICollectionViewFlowLayout {
+//
+//}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionFooterView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionFooterView.swift
@@ -1,0 +1,58 @@
+//
+//  PostReplyCollectionFooterView.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+final class PostReplyCollectionFooterView: UICollectionReusableView {
+    
+    // MARK: - Properties
+    
+    static let identifier = "PostReplyCollectionFooterView"
+    
+    // MARK: - UI Components
+    
+    private let footerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .orange
+        return view
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension PostReplyCollectionFooterView {
+    func setUI() {
+        self.backgroundColor = .donGray1
+    }
+    
+    func setHierarchy() {
+        self.addSubviews(footerView)
+    }
+    
+    func setLayout() {
+        footerView.snp.makeConstraints {
+            $0.height.equalTo(2.adjusted)
+            
+        }
+    }
+}
+

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionView.swift
@@ -61,6 +61,6 @@ private extension PostReplyCollectionView {
     
     func setRegisterCell() {
         PostReplyCollectionViewCell.register(collectionView: collectionView)
-        collectionView.register(HomeCollectionFooterView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "HomeCollectionFooterView")
+        collectionView.register(PostReplyCollectionFooterView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "PostReplyCollectionFooterView")
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
@@ -38,10 +38,11 @@ final class PostReplyTextFieldView: UIView {
         return image
     }()
     
-    private let textFieldView: UIView = {
+    public let greenTextFieldView: UIView = {
         let view = UIView()
         view.backgroundColor = .donPale
         view.layer.cornerRadius = 20.adjusted
+        view.isUserInteractionEnabled = true
         return view
     }()
     
@@ -82,13 +83,13 @@ extension PostReplyTextFieldView {
     
     private func setHierarchy() {
         addSubviews(horizontalDivierView, backgroundView)
-        backgroundView.addSubviews(profileImageView, textFieldView)
-        textFieldView.addSubviews(replyTextFieldLabel)
+        backgroundView.addSubviews(profileImageView, greenTextFieldView)
+        greenTextFieldView.addSubviews(replyTextFieldLabel)
     }
     
     private func setLayout() {
         horizontalDivierView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(1.adjusted)
         }
         
@@ -104,7 +105,7 @@ extension PostReplyTextFieldView {
             $0.centerY.equalToSuperview()
         }
         
-        textFieldView.snp.makeConstraints {
+        greenTextFieldView.snp.makeConstraints {
             $0.leading.equalTo(profileImageView.snp.trailing).offset(8.adjusted)
             $0.trailing.equalToSuperview().inset(16.adjusted)
             $0.height.equalTo(40.adjusted)
@@ -113,7 +114,7 @@ extension PostReplyTextFieldView {
         
         replyTextFieldLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(textFieldView.snp.leading).offset(16.adjusted)
+            $0.leading.equalTo(greenTextFieldView.snp.leading).offset(16.adjusted)
         }
         
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
@@ -76,7 +76,7 @@ final class PostView: UIView {
     private let contentTextLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donBlack
-        label.text = "돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다."
+        label.text = "돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다.돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다."
         label.lineBreakMode = .byCharWrapping
         label.font = .font(.body4)
         label.numberOfLines = 0
@@ -263,7 +263,7 @@ extension PostView {
         }
         
         horizontalDivierView.snp.makeConstraints {
-            $0.top.equalTo(PostbackgroundUIView.snp.bottom)
+            $0.bottom.equalTo(PostbackgroundUIView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1.adjusted)
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
@@ -1,15 +1,15 @@
 //
-//  WriteTextView.swift
+//  WriteReplyEditorView.swift
 //  DontBe-iOS
 //
-//  Created by 변상우 on 1/8/24.
+//  Created by yeonsu on 1/14/24.
 //
 
 import UIKit
 
 import SnapKit
 
-final class WriteTextView: UIView {
+final class WriteReplyEditorView: UIView {
 
     // MARK: - Properties
     
@@ -18,9 +18,17 @@ final class WriteTextView: UIView {
     
     // MARK: - UI Components
     
+    private let backgroundUIView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .donWhite
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
     private let userProfileImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.setCircularImage(image: ImageLiterals.Common.logoSymbol)
+        imageView.setCircularImage(image: ImageLiterals.Onboarding.imgOne)
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     
@@ -71,7 +79,7 @@ final class WriteTextView: UIView {
         return circle
     }()
     
-    public let postButton: UIButton = {
+    private let postButton: UIButton = {
         let button = UIButton()
         button.setTitle(StringLiterals.Write.writePostButtonTitle, for: .normal)
         button.setTitleColor(.donGray9, for: .normal)
@@ -87,10 +95,13 @@ final class WriteTextView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setDelegate()
         setUI()
+        setObserver()
         setHierarchy()
         setLayout()
+        setDelegate()
+        setAddTarget()
+        setRegisterCell()
     }
     
     @available(*, unavailable)
@@ -101,12 +112,16 @@ final class WriteTextView: UIView {
 
 // MARK: - Extensions
 
-extension WriteTextView {
+extension WriteReplyEditorView {
+    func setUI() {
+        self.backgroundColor = .donGray1
+    }
     func setDelegate() {
         self.contentTextView.delegate = self
+        
     }
     
-    func setUI() {
+    private func setObserver() {
         contentTextView.becomeFirstResponder()
         limitedCircleProgressBar.alpha = 0
         
@@ -116,21 +131,29 @@ extension WriteTextView {
         impactFeedbackGenerator.prepare()
     }
     
-    func setHierarchy() {
-        self.addSubviews(userProfileImage, 
-                         userNickname,
-                         contentTextView,
+    private func setHierarchy() {
+        self.addSubviews(backgroundUIView,
                          keyboardToolbarView)
+        
+        backgroundUIView.addSubviews(userProfileImage,
+                                     userNickname,
+                                     contentTextView)
         
         keyboardToolbarView.addSubviews(circleProgressBar,
                                         limitedCircleProgressBar,
                                         postButton)
     }
     
-    func setLayout() {
+    private func setLayout() {
+        backgroundUIView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.top.equalTo(8)
+            $0.bottom.equalToSuperview()
+        }
+        
         userProfileImage.snp.makeConstraints {
-            $0.top.equalTo(self.safeAreaLayoutGuide).offset(12.adjusted)
-            $0.leading.equalToSuperview().inset(16.adjusted)
+            $0.top.equalToSuperview().offset(18.adjusted)
+            $0.leading.equalToSuperview().offset(10.adjusted)
             $0.width.equalTo(44.adjusted)
             $0.height.equalTo(44.adjusted)
         }
@@ -182,9 +205,21 @@ extension WriteTextView {
             keyboardToolbarView.bottomAnchor.constraint(equalTo: self.keyboardLayoutGuide.topAnchor, constant: -keyboardHeight).isActive = true
         }
     }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setRegisterCell() {
+        
+    }
+    
+    private func setDataBind() {
+        
+    }
 }
 
-extension WriteTextView: UITextViewDelegate {
+extension WriteReplyEditorView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         let textLength = contentTextView.text.count
         textView.text = String(textView.text.prefix(maxLength))
@@ -213,3 +248,4 @@ extension WriteTextView: UITextViewDelegate {
         }
     }
 }
+

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
@@ -1,0 +1,119 @@
+//
+//  WriteReplyPostView.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class WriteReplyPostView: UIView {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let backgroundUIView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .donWhite
+        return view
+    }()
+    
+    private let profileImageView: UIImageView = {
+        let image = UIImageView()
+        image.contentMode = .scaleAspectFill
+        image.clipsToBounds = true
+        image.layer.cornerRadius = 22.adjusted
+        image.image = ImageLiterals.Onboarding.imgOne
+        return image
+    }()
+    
+    public let postNicknameLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .donBlack
+        label.text = "Don't be야 사랑해~"
+        label.font = .font(.body3)
+        return label
+    }()
+    
+    public let contentTextLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .donBlack
+        label.text = "돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다.돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다."
+        label.lineBreakMode = .byCharWrapping
+        label.font = .font(.body4)
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension WriteReplyPostView {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+        addSubviews(backgroundUIView)
+        backgroundUIView.addSubviews(profileImageView,
+                                     postNicknameLabel,
+                                     contentTextLabel)
+    }
+    
+    private func setLayout() {
+        backgroundUIView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.leading.equalTo(10.adjusted)
+            $0.top.equalTo(18.adjusted)
+            $0.size.equalTo(44.adjusted)
+        }
+        
+        postNicknameLabel.snp.makeConstraints {
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(8.adjusted)
+            $0.top.equalTo(profileImageView.snp.top).offset(4.adjusted)
+        }
+        
+        contentTextLabel.snp.makeConstraints {
+            $0.top.equalTo(postNicknameLabel.snp.bottom).offset(6.adjusted)
+            $0.leading.equalTo(postNicknameLabel)
+            $0.trailing.equalToSuperview().inset(20.adjusted)
+        }
+    }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setRegisterCell() {
+        
+    }
+    
+    private func setDataBind() {
+        
+    }
+}
+

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
@@ -1,0 +1,75 @@
+//
+//  WriteReplyView.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class WriteReplyView: UIView {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private lazy var writeReplyPostview = WriteReplyPostView()
+    private lazy var writeReplyView = WriteReplyEditorView()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension WriteReplyView {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+        addSubviews(writeReplyPostview,
+                    writeReplyView)
+    }
+    
+    private func setLayout() {
+        writeReplyPostview.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        writeReplyView.snp.makeConstraints {
+            $0.top.equalTo(writeReplyPostview.contentTextLabel.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setRegisterCell() {
+        
+    }
+    
+    private func setDataBind() {
+        
+    }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 게시글 상세 뷰에서 텍스트필드 영역 터치 시 답글 작성 뷰가 바텀시트로 나오도록 구현했습니다.
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 아직 action 연동 안 된 상태입니다!
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/b714dae0-9a37-4252-a4b0-eaca4b5da344" width ="250">|

## 📟 관련 이슈
- Resolved: #51
