### PR TITLE
Feat [#54] 마이페이지 계정 정보 UI 구현, 스크롤 자연스럽게 적용

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		3C6193172B3A7A7B00220CEB /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193162B3A7A7B00220CEB /* UIStackView+.swift */; };
 		3C6193192B3A7AC700220CEB /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193182B3A7AC700220CEB /* Config.swift */; };
 		3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C61931A2B3A7AD000220CEB /* NetworkError.swift */; };
+		3C7741522B5311750069E694 /* MyPageAccountInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */; };
+		3C7741542B531AC80069E694 /* AccountInfoDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741532B531AC80069E694 /* AccountInfoDummy.swift */; };
 		3CE9C12A2B4BE6780086E4A3 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C1292B4BE6780086E4A3 /* WriteViewController.swift */; };
 		3CE9C12C2B4BE7300086E4A3 /* WriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C12B2B4BE7300086E4A3 /* WriteView.swift */; };
 		3CE9C12E2B4C08AE0086E4A3 /* WriteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C12D2B4C08AE0086E4A3 /* WriteTextView.swift */; };
@@ -201,6 +203,8 @@
 		3C6193162B3A7A7B00220CEB /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3C6193182B3A7AC700220CEB /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		3C61931A2B3A7AD000220CEB /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAccountInfoTableViewCell.swift; sourceTree = "<group>"; };
+		3C7741532B531AC80069E694 /* AccountInfoDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoDummy.swift; sourceTree = "<group>"; };
 		3CE9C1292B4BE6780086E4A3 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
 		3CE9C12B2B4BE7300086E4A3 /* WriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteView.swift; sourceTree = "<group>"; };
 		3CE9C12D2B4C08AE0086E4A3 /* WriteTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextView.swift; sourceTree = "<group>"; };
@@ -676,6 +680,7 @@
 		3C8A262D2B5194C100E549F3 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -729,6 +734,7 @@
 			isa = PBXGroup;
 			children = (
 				3CEE4CBF2B500BE500F506AF /* TransparencyInfoDummy.swift */,
+				3C7741532B531AC80069E694 /* AccountInfoDummy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -930,6 +936,8 @@
 				2A84465A2B4EE8B400F98F2A /* JoinProfileViewController.swift in Sources */,
 				2A8868DA2B506D720017513A /* NotificationViewController.swift in Sources */,
 				3C4993652B4F2471002A99CF /* MyPageSegmentedControl.swift in Sources */,
+				3C7741542B531AC80069E694 /* AccountInfoDummy.swift in Sources */,
+				3C7741522B5311750069E694 /* MyPageAccountInfoTableViewCell.swift in Sources */,
 				3CF184CD2B4EEC1900816D5F /* MyPageView.swift in Sources */,
 				2FB818D32B51694F00B7498F /* PostView.swift in Sources */,
 				3C2854FF2B3AA01700369C99 /* ExampleView.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Cells/MyPageAccountInfoTableViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Cells/MyPageAccountInfoTableViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class MyPageAccountInfoTableViewCell: UITableViewCell {
+final class MyPageAccountInfoTableViewCell: UITableViewCell {
     
     // MARK: - Properties
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Cells/MyPageAccountInfoTableViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Cells/MyPageAccountInfoTableViewCell.swift
@@ -1,0 +1,77 @@
+//
+//  MyPageAccountInfoTableViewCell.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/14/24.
+//
+
+import UIKit
+
+import SnapKit
+
+class MyPageAccountInfoTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "MyPageAccountInfoTableViewCell"
+    
+    // MARK: - UI Components
+    
+    let infoTitle: UILabel = {
+        let label = UILabel()
+        label.font = .font(.body3)
+        label.textColor = .donBlack
+        return label
+    }()
+    
+    let infoContent: UILabel = {
+        let label = UILabel()
+        label.font = .font(.body4)
+        label.textColor = .donGray7
+        return label
+    }()
+    
+    // MARK: - Life Cycles
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("")
+    }
+}
+
+// MARK: - Extensions
+
+extension MyPageAccountInfoTableViewCell {
+    func setUI() {
+        
+    }
+    
+    func setHierarchy() {
+        self.addSubviews(infoTitle,
+                         infoContent)
+    }
+    
+    func setLayout() {
+        infoTitle.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16.adjusted)
+        }
+        
+        infoContent.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(15.adjusted)
+        }
+    }
+    
+    func setAddTarget() {
+        
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Helpers/AccountInfoDummy.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Helpers/AccountInfoDummy.swift
@@ -1,0 +1,23 @@
+//
+//  AccountInfoDummy.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/14/24.
+//
+
+import Foundation
+
+struct AccountInfoDummy {
+    let content: String
+}
+
+extension AccountInfoDummy {
+    static func dummy() -> [AccountInfoDummy] {
+        return [
+            AccountInfoDummy(content: "카카오톡 소셜로그인"),
+            AccountInfoDummy(content: "v.1.0.01"),
+            AccountInfoDummy(content: "money_rain_is_coming"),
+            AccountInfoDummy(content: "2024.01.14")
+        ]
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -26,6 +26,8 @@ final class MyPageAccountInfoViewController: UIViewController {
     private let accountInfoTableView: UITableView = {
         let tableView = UITableView()
         tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
+        tableView.isUserInteractionEnabled = false
         return tableView
     }()
     
@@ -76,6 +78,7 @@ final class MyPageAccountInfoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .donWhite
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
         
@@ -90,6 +93,12 @@ extension MyPageAccountInfoViewController {
     private func setUI() {
         self.title = "계정 정보"
         self.view.backgroundColor = .donWhite
+        
+        self.navigationController?.navigationBar.barTintColor = .donWhite
+        self.navigationController?.navigationBar.tintColor = .donWhite
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
+        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
+        
         addUnderline(to: moreInfoButton)
         addUnderline(to: signOutButton)
     }
@@ -182,6 +191,7 @@ extension MyPageAccountInfoViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MyPageAccountInfoTableViewCell", for: indexPath) as! MyPageAccountInfoTableViewCell
+        cell.backgroundColor = .donWhite
         cell.infoTitle.text = titleData[indexPath.row]
         cell.infoContent.text = infoData[indexPath.row].content
         return cell

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -7,28 +7,203 @@
 
 import UIKit
 
-class MyPageAccountInfoViewController: UIViewController {
+import SnapKit
 
+final class MyPageAccountInfoViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    var titleData = [
+        "소셜 로그인",
+        "버전 정보",
+        "아이디",
+        "가입일"
+    ]
+    var infoData = AccountInfoDummy.dummy()
+    
+    // MARK: - UI Components
+    
+    private let accountInfoTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.separatorStyle = .none
+        return tableView
+    }()
+    
+    private let seperateView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .donGray2
+        return view
+    }()
+    
+    private let moreInfoTitle: UILabel = {
+        let label = UILabel()
+        label.font = .font(.body3)
+        label.text = "이용약관"
+        label.textColor = .donBlack
+        return label
+    }()
+    
+    private let moreInfoButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("자세히 보기", for: .normal)
+        button.setTitleColor(.donGray7, for: .normal)
+        button.titleLabel?.font = .font(.body4)
+        return button
+    }()
+    
+    private let signOutButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("회원탈퇴", for: .normal)
+        button.setTitleColor(.donGray7, for: .normal)
+        button.titleLabel?.font = .font(.body4)
+        return button
+    }()
+    
+    // MARK: - Life Cycles
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        tabBarController?.tabBar.isHidden = true
-        self.view.backgroundColor = .donError
-        self.title = StringLiterals.MyPage.MyPageAccountInfoNavigationTitle
+        
+        getAPI()
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setDelegate()
+        setRegisterCell()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
         
-        let backButton = UIBarButtonItem.backButton(target: self, action: #selector(backButtonPressed))
+        let backButton = UIBarButtonItem.backButton(target: self, action: #selector(backButtonTapped))
         self.navigationItem.leftBarButtonItem = backButton
     }
+}
 
-    @objc
-    private func backButtonPressed() {
-        self.navigationController?.popViewController(animated: true)
+// MARK: - Extensions
+
+extension MyPageAccountInfoViewController {
+    private func setUI() {
+        self.title = "계정 정보"
+        self.view.backgroundColor = .donWhite
+        addUnderline(to: moreInfoButton)
+        addUnderline(to: signOutButton)
     }
     
+    private func setHierarchy() {
+        self.view.addSubviews(accountInfoTableView,
+                              seperateView,
+                              moreInfoTitle,
+                              moreInfoButton,
+                              signOutButton)
+    }
+    
+    private func setLayout() {
+        accountInfoTableView.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo((48 * 4).adjusted)
+        }
+        
+        seperateView.snp.makeConstraints {
+            $0.top.equalTo(accountInfoTableView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(8.adjusted)
+        }
+        
+        moreInfoTitle.snp.makeConstraints {
+            $0.top.equalTo(seperateView.snp.bottom).offset(14.adjusted)
+            $0.leading.equalToSuperview().inset(16.adjusted)
+        }
+        
+        moreInfoButton.snp.makeConstraints {
+            $0.top.equalTo(seperateView.snp.bottom).offset(14.adjusted)
+            $0.trailing.equalToSuperview().inset(15.adjusted)
+        }
+        
+        signOutButton.snp.makeConstraints {
+            $0.top.equalTo(moreInfoButton.snp.bottom).offset(27.adjusted)
+            $0.trailing.equalTo(moreInfoButton.snp.trailing)
+        }
+    }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setDelegate() {
+        self.accountInfoTableView.dataSource = self
+        self.accountInfoTableView.delegate = self
+    }
+    
+    private func setRegisterCell() {
+        self.accountInfoTableView.register(MyPageAccountInfoTableViewCell.self, forCellReuseIdentifier: "MyPageAccountInfoTableViewCell")
+    }
+    
+    private func setDataBind() {
+        
+    }
+    
+    func addUnderline(to button: UIButton) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .underlineColor: UIColor.donGray7
+        ]
+
+        let attributedString = NSAttributedString(string: button.currentTitle ?? "", attributes: attributes)
+        button.setAttributedTitle(attributedString, for: .normal)
+    }
+
+    
+    @objc
+    private func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
+    }
 }
+
+extension MyPageAccountInfoViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        print("ddd")
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 48.adjusted
+    }
+}
+
+extension MyPageAccountInfoViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 4
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MyPageAccountInfoTableViewCell", for: indexPath) as! MyPageAccountInfoTableViewCell
+        cell.infoTitle.text = titleData[indexPath.row]
+        cell.infoContent.text = infoData[indexPath.row].content
+        return cell
+    }
+}
+
+// MARK: - Network
+
+extension MyPageAccountInfoViewController {
+    private func getAPI() {
+        
+    }
+}
+
+//extension ExampleViewController: UICollectionViewDelegate {
+//
+//}
+//
+//extension ExampleViewController: UICollectionViewDataSource {
+//
+//}
+//
+//extension ExampleViewController: UICollectionViewFlowLayout {
+//
+//}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -26,6 +26,8 @@ final class MyPageAccountInfoViewController: UIViewController {
     private let accountInfoTableView: UITableView = {
         let tableView = UITableView()
         tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
+        tableView.isUserInteractionEnabled = false
         return tableView
     }()
     
@@ -76,6 +78,7 @@ final class MyPageAccountInfoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .donWhite
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
         
@@ -90,6 +93,12 @@ extension MyPageAccountInfoViewController {
     private func setUI() {
         self.title = "계정 정보"
         self.view.backgroundColor = .donWhite
+        
+        self.navigationController?.navigationBar.barTintColor = .donWhite
+        self.navigationController?.navigationBar.tintColor = .donWhite
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
+        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
+        
         addUnderline(to: moreInfoButton)
         addUnderline(to: signOutButton)
     }
@@ -167,7 +176,7 @@ extension MyPageAccountInfoViewController {
 
 extension MyPageAccountInfoViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        print("ddd")
+        
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -182,6 +191,7 @@ extension MyPageAccountInfoViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "MyPageAccountInfoTableViewCell", for: indexPath) as! MyPageAccountInfoTableViewCell
+        cell.backgroundColor = .donWhite
         cell.infoTitle.text = titleData[indexPath.row]
         cell.infoContent.text = infoData[indexPath.row].content
         return cell

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -67,7 +67,7 @@ extension MyPageContentViewController {
         
         uploadToastView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview().inset(16.adjusted)
-            $0.height.equalTo(44)
+            $0.height.equalTo(44.adjusted)
         }
         
         transparentButtonPopupView.snp.makeConstraints {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -13,7 +13,6 @@ final class MyPageContentViewController: UIViewController {
     
     // MARK: - Properties
     
-    var tabBarHeight: CGFloat = 0
     var showUploadToastView: Bool = false
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     private let refreshControl = UIRefreshControl()
@@ -42,14 +41,6 @@ final class MyPageContentViewController: UIViewController {
         setNotification()
         setRefreshControll()
     }
-    
-    // MARK: - TabBar Height
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        tabBarHeight = tabBarController?.tabBar.frame.size.height ?? 0
-    }
 }
 
 // MARK: - Extensions
@@ -70,14 +61,12 @@ extension MyPageContentViewController {
     
     private func setLayout() {
         homeCollectionView.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.edges.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width)
         }
         
         uploadToastView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16.adjusted)
-            $0.bottom.equalTo(tabBarHeight).inset(6.adjusted)
+            $0.leading.trailing.bottom.equalToSuperview().inset(16.adjusted)
             $0.height.equalTo(44)
         }
         
@@ -209,7 +198,6 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
 extension MyPageContentViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let yOffset = scrollView.contentOffset.y
-        let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
         if yOffset > 0 {
             scrollView.isScrollEnabled = true
         } else if yOffset < 0 {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -97,7 +97,11 @@ extension MyPageViewController {
     private func setUI() {
         self.view.backgroundColor = .donBlack
         self.tabBarController?.tabBar.isTranslucent = true
-        self.title = StringLiterals.MyPage.MyPageNavigationTitle
+        
+        self.navigationItem.title = StringLiterals.MyPage.MyPageNavigationTitle
+        self.navigationController?.navigationBar.barTintColor = .donBlack
+        self.navigationController?.navigationBar.tintColor = .donBlack
+        self.navigationController?.navigationBar.backgroundColor = .donBlack
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donWhite]
         
         let image = ImageLiterals.MyPage.icnMenu

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 final class MyPageViewController: UIViewController {
     
     // MARK: - Properties
@@ -27,9 +29,13 @@ final class MyPageViewController: UIViewController {
         }
     }
     
+    var tabBarHeight: CGFloat = 0
+    
     // MARK: - UI Components
     
     let rootView = MyPageView()
+    
+    let statusBarView = UIView(frame: UIApplication.shared.statusBarFrame)
     
     // MARK: - Life Cycles
     
@@ -43,6 +49,7 @@ final class MyPageViewController: UIViewController {
         
         getAPI()
         setUI()
+        setLayout()
         setDelegate()
         setAddTarget()
     }
@@ -51,6 +58,40 @@ final class MyPageViewController: UIViewController {
         super.viewWillAppear(true)
         
         tabBarController?.tabBar.isHidden = false
+        self.navigationController?.navigationBar.tintColor = .donBlack
+        self.navigationController?.navigationBar.barTintColor = .donBlack
+        self.navigationController?.navigationBar.backgroundColor = .donBlack
+        self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationController?.navigationBar.isTranslucent = true
+        
+        statusBarView.backgroundColor = UIColor.donBlack
+        view.addSubview(statusBarView)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        
+        self.navigationController?.navigationBar.tintColor = .donWhite
+        self.navigationController?.navigationBar.barTintColor = .donWhite
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
+        
+        statusBarView.removeFromSuperview()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let safeAreaHeight = view.safeAreaInsets.bottom
+        let tabBarHeight: CGFloat = 70.0
+        
+        self.tabBarHeight = tabBarHeight + safeAreaHeight
+        
+        rootView.pageViewController.view.snp.remakeConstraints {
+            $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
+            $0.leading.trailing.equalToSuperview()
+            let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
+            $0.height.equalTo(UIScreen.main.bounds.height - statusBarHeight - navigationBarHeight - self.tabBarHeight)
+        }
     }
 }
 
@@ -62,15 +103,6 @@ extension MyPageViewController {
         self.tabBarController?.tabBar.isTranslucent = true
         self.title = StringLiterals.MyPage.MyPageNavigationTitle
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donWhite]
-        self.navigationController?.navigationBar.tintColor = .donBlack
-        self.navigationController?.navigationBar.barTintColor = .donBlack
-        self.navigationController?.navigationBar.backgroundColor = .donBlack
-        self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
-        self.navigationController?.navigationBar.isTranslucent = true
-        
-        let statusBarView = UIView(frame: UIApplication.shared.statusBarFrame)
-        statusBarView.backgroundColor = UIColor.donBlack  // 적절한 색상으로 변경 가능
-        view.addSubview(statusBarView)
         
         let image = ImageLiterals.MyPage.icnMenu
         let renderedImage = image.withRenderingMode(.alwaysOriginal)
@@ -80,6 +112,13 @@ extension MyPageViewController {
                                               action: #selector(hambergerButtonTapped))
         
         navigationItem.rightBarButtonItem = hambergerButton
+    }
+    
+    private func setLayout() {
+        rootView.pageViewController.view.snp.makeConstraints {
+            $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
+            $0.leading.trailing.equalToSuperview()
+        }
     }
     
     private func setDelegate() {
@@ -185,28 +224,52 @@ extension MyPageViewController: UIPageViewControllerDataSource, UIPageViewContro
 extension MyPageViewController: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         
-        let yOffset = scrollView.contentOffset.y
+        var yOffset = scrollView.contentOffset.y
         let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
-        let homeCollectionView = rootView.pageViewController.view.frame.origin.y
         
         scrollView.isScrollEnabled = true
         rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = false
+        rootView.myPageContentViewController.homeCollectionView.isUserInteractionEnabled = false
         
-        if yOffset <= -91.adjusted {
+        if yOffset <= -(navigationBarHeight + statusBarHeight) {
             rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = false
-        } else if yOffset >= (rootView.myPageProfileView.frame.height - statusBarHeight - navigationBarHeight) {
-            rootView.segmentedControl.frame.origin.y = yOffset - rootView.myPageProfileView.frame.height + statusBarHeight + navigationBarHeight
+            rootView.myPageContentViewController.homeCollectionView.isUserInteractionEnabled = false
+            
+            yOffset = -(navigationBarHeight + statusBarHeight)
+            rootView.segmentedControl.frame.origin.y = yOffset + statusBarHeight + navigationBarHeight
             rootView.segmentedControl.snp.remakeConstraints {
-                $0.top.equalTo(rootView.segmentedControl.frame.origin.y)
+                $0.top.equalTo(rootView.myPageProfileView.snp.bottom)
                 $0.leading.trailing.equalToSuperview()
                 $0.height.equalTo(54.adjusted)
             }
+            
+            rootView.pageViewController.view.snp.remakeConstraints {
+                $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
+                $0.leading.trailing.equalToSuperview()
+                let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
+                $0.height.equalTo(UIScreen.main.bounds.height - statusBarHeight - navigationBarHeight - self.tabBarHeight)
+            }
+        } else if yOffset >= (rootView.myPageProfileView.frame.height - statusBarHeight - navigationBarHeight) {
+            rootView.segmentedControl.frame.origin.y = yOffset - rootView.myPageProfileView.frame.height + statusBarHeight + navigationBarHeight
+            rootView.segmentedControl.snp.remakeConstraints {
+                $0.top.equalTo(rootView.myPageProfileView.snp.bottom)
+                $0.leading.trailing.equalToSuperview()
+                $0.height.equalTo(54.adjusted)
+            }
+            
+            rootView.pageViewController.view.frame.origin.y = yOffset - rootView.myPageProfileView.frame.height + statusBarHeight + navigationBarHeight + rootView.segmentedControl.frame.height
+            
+            rootView.pageViewController.view.snp.remakeConstraints {
+                $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
+                $0.leading.trailing.equalToSuperview()
+                let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
+                $0.height.equalTo(UIScreen.main.bounds.height - statusBarHeight - navigationBarHeight - self.tabBarHeight)
+            }
+            
             scrollView.setContentOffset(CGPoint(x: 0, y: yOffset), animated: true)
             
             rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = true
-            scrollView.isScrollEnabled = true
-        } else {
-            rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = true
+            rootView.myPageContentViewController.homeCollectionView.isUserInteractionEnabled = true
         }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -78,7 +78,7 @@ final class MyPageViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         let safeAreaHeight = view.safeAreaInsets.bottom
-        let tabBarHeight: CGFloat = 70.0
+        let tabBarHeight: CGFloat = 70.0.adjusted
         
         self.tabBarHeight = tabBarHeight + safeAreaHeight
         
@@ -97,7 +97,11 @@ extension MyPageViewController {
     private func setUI() {
         self.view.backgroundColor = .donBlack
         self.tabBarController?.tabBar.isTranslucent = true
-        self.title = StringLiterals.MyPage.MyPageNavigationTitle
+        
+        self.navigationItem.title = StringLiterals.MyPage.MyPageNavigationTitle
+        self.navigationController?.navigationBar.barTintColor = .donBlack
+        self.navigationController?.navigationBar.tintColor = .donBlack
+        self.navigationController?.navigationBar.backgroundColor = .donBlack
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donWhite]
         
         let image = ImageLiterals.MyPage.icnMenu

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -71,10 +71,6 @@ final class MyPageViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
         
-        self.navigationController?.navigationBar.tintColor = .donWhite
-        self.navigationController?.navigationBar.barTintColor = .donWhite
-        self.navigationController?.navigationBar.backgroundColor = .donWhite
-        
         statusBarView.removeFromSuperview()
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
@@ -142,7 +142,7 @@ extension MyPageView {
         pageViewController.view.snp.makeConstraints {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(2.adjusted)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(UIScreen.main.bounds.height - 150)
+            $0.height.equalTo(UIScreen.main.bounds.height - 150.adjusted)
         }
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
@@ -119,7 +119,7 @@ extension MyPageView {
         }
         
         myPageContentView.snp.makeConstraints {
-            $0.top.leading.bottom.equalToSuperview()
+            $0.edges.equalToSuperview()
             $0.width.equalTo(myPageScrollView.snp.width)
             $0.height.equalTo(2000)
         }
@@ -142,7 +142,7 @@ extension MyPageView {
         pageViewController.view.snp.makeConstraints {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(2.adjusted)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2000)
+            $0.height.equalTo(UIScreen.main.bounds.height - 150)
         }
     }
     


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 마이페이지 계정 정보 UI 구현했습니다!
- 스크롤 자연스럽게 적용시켰습니다!
 
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 네비게이션 바 색상이 부자연스럽게 바뀌는데 한번 나중에 수정해보겠습니다!

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷
|:--:|:--:|:--:|:--:|
|스크롤 적용|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/eced6551-3cc9-46bb-b952-b14a58d4698b" width ="250">|계정 정보 UI|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/84786477-db4e-4cbf-b464-cb91b54e3e8e" width ="250">|


## 📟 관련 이슈
- Resolved: #54 
