### PR TITLE
Feat [#58] 홈 + 게시글 뷰 액션 추가

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		2FB818DC2B51875D00B7498F /* PostReplyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */; };
 		2FBBADF12B53AF9B002D6286 /* PostReplyCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */; };
 		2FBBADF42B53BEB5002D6286 /* TransparentPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */; };
+		2FBBADF62B53EEBD002D6286 /* CancelReplyPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF52B53EEBD002D6286 /* CancelReplyPopupViewController.swift */; };
+		2FBBADF82B53EF63002D6286 /* PostPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF72B53EF63002D6286 /* PostPopupView.swift */; };
 		3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */; };
 		3C0920DE2B4D98CD003BD080 /* DontBeToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */; };
 		3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */; };
@@ -187,6 +189,8 @@
 		2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionViewCell.swift; sourceTree = "<group>"; };
 		2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionFooterView.swift; sourceTree = "<group>"; };
 		2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentPopupViewController.swift; sourceTree = "<group>"; };
+		2FBBADF52B53EEBD002D6286 /* CancelReplyPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelReplyPopupViewController.swift; sourceTree = "<group>"; };
+		2FBBADF72B53EF63002D6286 /* PostPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPopupView.swift; sourceTree = "<group>"; };
 		3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBePopupView.swift; sourceTree = "<group>"; };
 		3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeToastView.swift; sourceTree = "<group>"; };
 		3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
@@ -460,6 +464,7 @@
 				2FB64FEF2B5310DD0082A414 /* WriteReplyViewController.swift */,
 				2FB818D02B51693400B7498F /* PostViewController.swift */,
 				2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */,
+				2FBBADF52B53EEBD002D6286 /* CancelReplyPopupViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -469,6 +474,7 @@
 			children = (
 				2FB818D42B517EE700B7498F /* PostDetailView.swift */,
 				2FB818D22B51694F00B7498F /* PostView.swift */,
+				2FBBADF72B53EF63002D6286 /* PostPopupView.swift */,
 				2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */,
 				2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */,
 				2FB769CF2B5277BD004C7752 /* PostReplyTextFieldView.swift */,
@@ -857,6 +863,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FBBADF62B53EEBD002D6286 /* CancelReplyPopupViewController.swift in Sources */,
 				2A8D70CA2B4D9787009F4C6C /* IntroductionView.swift in Sources */,
 				2A8D70CA2B4D9787009F4C6C /* IntroductionView.swift in Sources */,
 				3C6193172B3A7A7B00220CEB /* UIStackView+.swift in Sources */,
@@ -955,6 +962,7 @@
 				2A28453E2B531DDE0023F9B5 /* NetworkService.swift in Sources */,
 				2AC9FB1B2B4DE77400D31071 /* AgreementListCustomView.swift in Sources */,
 				2F17418A2B500CC20089FC4D /* HomeBottomsheetView.swift in Sources */,
+				2FBBADF82B53EF63002D6286 /* PostPopupView.swift in Sources */,
 				2FB64FF02B5310DD0082A414 /* WriteReplyViewController.swift in Sources */,
 				3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */,
 				2A2671FF2B4C3AF0009D214F /* Publisher+UIControl.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		2FBBADF42B53BEB5002D6286 /* TransparentPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */; };
 		2FBBADF62B53EEBD002D6286 /* CancelReplyPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF52B53EEBD002D6286 /* CancelReplyPopupViewController.swift */; };
 		2FBBADF82B53EF63002D6286 /* PostPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF72B53EF63002D6286 /* PostPopupView.swift */; };
+		2FBBADFA2B54401A002D6286 /* DeletePopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF92B54401A002D6286 /* DeletePopupViewController.swift */; };
 		3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */; };
 		3C0920DE2B4D98CD003BD080 /* DontBeToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */; };
 		3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */; };
@@ -191,6 +192,7 @@
 		2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentPopupViewController.swift; sourceTree = "<group>"; };
 		2FBBADF52B53EEBD002D6286 /* CancelReplyPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelReplyPopupViewController.swift; sourceTree = "<group>"; };
 		2FBBADF72B53EF63002D6286 /* PostPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPopupView.swift; sourceTree = "<group>"; };
+		2FBBADF92B54401A002D6286 /* DeletePopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePopupViewController.swift; sourceTree = "<group>"; };
 		3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBePopupView.swift; sourceTree = "<group>"; };
 		3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeToastView.swift; sourceTree = "<group>"; };
 		3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
@@ -667,6 +669,7 @@
 			isa = PBXGroup;
 			children = (
 				2F8735412B4BE66500E55552 /* HomeViewController.swift */,
+				2FBBADF92B54401A002D6286 /* DeletePopupViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -880,6 +883,7 @@
 				2FB64FF22B5318C50082A414 /* WriteReplyPostView.swift in Sources */,
 				2FB818D52B517EE700B7498F /* PostDetailView.swift in Sources */,
 				2F8735462B4C34A500E55552 /* HomeCollectionView.swift in Sources */,
+				2FBBADFA2B54401A002D6286 /* DeletePopupViewController.swift in Sources */,
 				3CEE4CBD2B500A7800F506AF /* DontBeTransparencyInfoView.swift in Sources */,
 				2F8735422B4BE66500E55552 /* HomeViewController.swift in Sources */,
 				2A0A730E2B5438B5004478C1 /* KeychainWrapper.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		2FB818D92B5186FC00B7498F /* PostReplyCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */; };
 		2FB818DC2B51875D00B7498F /* PostReplyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */; };
 		2FBBADF12B53AF9B002D6286 /* PostReplyCollectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */; };
+		2FBBADF42B53BEB5002D6286 /* TransparentPopupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */; };
 		3C01692A2B4DC82D0075334B /* DontBePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */; };
 		3C0920DE2B4D98CD003BD080 /* DontBeToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */; };
 		3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */; };
@@ -185,6 +186,7 @@
 		2FB818D82B5186FC00B7498F /* PostReplyCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionView.swift; sourceTree = "<group>"; };
 		2FB818DB2B51875D00B7498F /* PostReplyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionViewCell.swift; sourceTree = "<group>"; };
 		2FBBADF02B53AF9B002D6286 /* PostReplyCollectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyCollectionFooterView.swift; sourceTree = "<group>"; };
+		2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentPopupViewController.swift; sourceTree = "<group>"; };
 		3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBePopupView.swift; sourceTree = "<group>"; };
 		3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeToastView.swift; sourceTree = "<group>"; };
 		3C2854FC2B3A9FD800369C99 /* ExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 			children = (
 				2FB64FEF2B5310DD0082A414 /* WriteReplyViewController.swift */,
 				2FB818D02B51693400B7498F /* PostViewController.swift */,
+				2FBBADF32B53BEB5002D6286 /* TransparentPopupViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -884,6 +887,7 @@
 				3CE9C1352B4C4BC20086E4A3 /* CircleProgressbar.swift in Sources */,
 				2AF069B22B518F8E00CA3E48 /* MyPageNicknameEditView.swift in Sources */,
 				2FB64FF42B531A5C0082A414 /* WriteReplyView.swift in Sources */,
+				2FBBADF42B53BEB5002D6286 /* TransparentPopupViewController.swift in Sources */,
 				3C6193192B3A7AC700220CEB /* Config.swift in Sources */,
 				3CF184D12B4EFF9900816D5F /* MyPageProfileView.swift in Sources */,
 				3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -112,5 +112,9 @@ enum StringLiterals {
     enum Post {
         static let navigationTitleLabel = "게시글"
         static let textFieldLabel = "님에게 답글 남기기"
+        static let popupReplyContentLabel = "작성 중인 글을 삭제하시겠어요?"
+        static let popupReplyCancelButtonTitle = "취소"
+        static let popupReplyConfirmButtonTitle = "삭제"
+        
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -107,6 +107,10 @@ enum StringLiterals {
         static let transparentPopupContentLabel = "지금 누르신 투명도 기능이 Don’t be를 더 온화한 커뮤니티로 만들기 위한 일이겠죠?"
         static let transparentPopupLefteftButtonTitle = "조금 더 고민하기"
         static let transparentPopupRightButtonTitle = "네, 맞아요"
+        static let deletePopupTitleLabel = "게시글을 삭제하시겠어요?"
+        static let deletePopupContentLabel = "삭제한 게시글은 영구히 사라져요."
+        static let deletePopupLefteftButtonTitle = "취소"
+        static let deletePopupRightButtonTitle = "삭제"
     }
     
     enum Post {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeBottomSheetView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeBottomSheetView.swift
@@ -17,13 +17,13 @@ final class DontBeBottomSheetView: UIView {
     
     // MARK: - UI Components
     
-    private let dimView: UIView = {
+    let dimView: UIView = {
         let view = UIView()
         view.backgroundColor = .donBlack.withAlphaComponent(0.6)
         return view
     }()
     
-    private let bottomsheetView: UIView = {
+    let bottomsheetView: UIView = {
         let view = UIView()
         view.backgroundColor = .donWhite
         view.layer.cornerRadius = 8.adjusted
@@ -37,9 +37,15 @@ final class DontBeBottomSheetView: UIView {
         return view
     }()
     
-    let singleButton: UIButton = {
+    let deleteButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Posting.btnDelete, for: .normal)
+        return button
+    }()
+    
+    let warnButton: UIButton = {
+        let button = UIButton()
+        button.setImage(ImageLiterals.Posting.btnWarn, for: .normal)
         return button
     }()
     
@@ -71,8 +77,6 @@ final class DontBeBottomSheetView: UIView {
     
     init(singleButtonImage: UIImage) {
         super.init(frame: .zero)
-        
-        singleButton.setImage(singleButtonImage, for: .normal)
         
         setUI()
         setHierarchy()
@@ -111,7 +115,7 @@ extension DontBeBottomSheetView {
         self.addSubviews(dimView,
                          bottomsheetView)
         bottomsheetView.addSubviews(dragIndicatorView,
-                                    singleButton)
+                                    deleteButton)
     }
     
     private func setLayout() {
@@ -126,7 +130,7 @@ extension DontBeBottomSheetView {
             $0.top.equalTo(19.adjusted)
         }
         
-        singleButton.snp.makeConstraints {
+        deleteButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.width.equalTo(344.adjusted)
             $0.height.equalTo(60.adjusted)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/DeletePopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/DeletePopupViewController.swift
@@ -1,0 +1,82 @@
+//
+//  DeletePopupViewController.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/15/24.
+//
+
+import UIKit
+
+final class DeletePopupViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let deletePostPopupView = DontBePopupView(popupTitle: StringLiterals.Home.deletePopupTitleLabel,
+                                                      popupContent: StringLiterals.Home.deletePopupContentLabel,
+                                                      leftButtonTitle: StringLiterals.Home.deletePopupLefteftButtonTitle,
+                                                      rightButtonTitle: StringLiterals.Home.deletePopupRightButtonTitle)
+    
+    private let myView = PostPopupView()
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = myView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        getAPI()
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+
+extension DeletePopupViewController {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+        view.addSubviews(deletePostPopupView)
+    }
+    
+    private func setLayout() {
+        deletePostPopupView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func setDelegate() {
+        deletePostPopupView.delegate = self
+    }
+}
+
+// MARK: - Network
+
+extension DeletePopupViewController {
+    private func getAPI() {
+        
+    }
+}
+
+extension DeletePopupViewController: DontBePopupDelegate {
+    func cancleButtonTapped() {
+        self.dismiss(animated: false)
+    }
+    
+    func confirmButtonTapped() {
+        self.dismiss(animated: false)
+        // ✅ 투명도 주기 버튼 클릭 시 액션 추가
+    }
+}
+

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -17,18 +17,13 @@ final class HomeViewController: UIViewController {
     var showUploadToastView: Bool = false
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     private let refreshControl = UIRefreshControl()
+    var transparentPopupVC = TransparentPopupViewController()
     
     // MARK: - UI Components
     
     private let myView = HomeView()
     private lazy var homeCollectionView = HomeCollectionView().collectionView
     private let uploadToastView = DontBeToastView()
-    
-    private let transparentButtonPopupView = DontBePopupView(popupImage: ImageLiterals.Popup.transparentButtonImage,
-                                                             popupTitle: StringLiterals.Home.transparentPopupTitleLabel,
-                                                             popupContent: StringLiterals.Home.transparentPopupContentLabel,
-                                                             leftButtonTitle: StringLiterals.Home.transparentPopupLefteftButtonTitle,
-                                                             rightButtonTitle: StringLiterals.Home.transparentPopupRightButtonTitle)
     
     // MARK: - Life Cycles
     
@@ -69,13 +64,12 @@ extension HomeViewController {
     private func setUI() {
         self.view.backgroundColor = UIColor.donGray1
         uploadToastView.alpha = 0
-        transparentButtonPopupView.alpha = 0
+        transparentPopupVC.modalPresentationStyle = .overFullScreen
     }
     
     private func setHierarchy() {
         view.addSubviews(homeCollectionView,
-                         uploadToastView,
-                         transparentButtonPopupView)
+                         uploadToastView)
     }
     
     private func setLayout() {
@@ -90,16 +84,11 @@ extension HomeViewController {
             $0.bottom.equalTo(tabBarHeight.adjusted).inset(6.adjusted)
             $0.height.equalTo(44)
         }
-        
-        transparentButtonPopupView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
     }
     
     private func setDelegate() {
         homeCollectionView.dataSource = self
         homeCollectionView.delegate = self
-        transparentButtonPopupView.delegate = self
     }
     
     private func setNotification() {
@@ -112,7 +101,7 @@ extension HomeViewController {
         refreshControl.backgroundColor = .donGray1
     }
     
-    @objc 
+    @objc
     func refreshPost() {
         DispatchQueue.main.async {
             // ✅ 서버 통신 영역
@@ -121,11 +110,11 @@ extension HomeViewController {
         self.homeCollectionView.reloadData()
         self.perform(#selector(self.finishedRefreshing), with: nil, afterDelay: 0.1)
     }
-      
-      @objc 
+    
+    @objc
     func finishedRefreshing() {
-            refreshControl.endRefreshing()
-      }
+        refreshControl.endRefreshing()
+    }
     
     
     
@@ -196,7 +185,8 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
             cell.likeButton.setImage(cell.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
         }
         cell.TransparentButtonAction = {
-            self.transparentButtonPopupView.alpha = 1
+            // present
+            self.present(self.transparentPopupVC, animated: false, completion: nil)
         }
         return cell
     }
@@ -214,16 +204,5 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         
         return CGSize(width: UIScreen.main.bounds.width, height: 24.adjusted)
-    }
-}
-
-extension HomeViewController: DontBePopupDelegate {
-    func cancleButtonTapped() {
-        transparentButtonPopupView.alpha = 0
-    }
-    
-    func confirmButtonTapped() {
-        transparentButtonPopupView.alpha = 0
-        // ✅ 투명도 주기 버튼 클릭 시 액션 추가
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -18,6 +18,7 @@ final class HomeViewController: UIViewController {
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     private let refreshControl = UIRefreshControl()
     var transparentPopupVC = TransparentPopupViewController()
+    var deletePostPopupVC = CancelReplyPopupViewController()
     
     // MARK: - UI Components
     
@@ -43,6 +44,7 @@ final class HomeViewController: UIViewController {
         setDelegate()
         setNotification()
         setRefreshControll()
+        setAddTarget()
     }
     
     // MARK: - TabBar Height
@@ -65,6 +67,7 @@ extension HomeViewController {
         self.view.backgroundColor = UIColor.donGray1
         uploadToastView.alpha = 0
         transparentPopupVC.modalPresentationStyle = .overFullScreen
+        deletePostPopupVC.modalPresentationStyle = .overFullScreen
     }
     
     private func setHierarchy() {
@@ -84,6 +87,38 @@ extension HomeViewController {
             $0.bottom.equalTo(tabBarHeight.adjusted).inset(6.adjusted)
             $0.height.equalTo(44)
         }
+    }
+    
+    private func setAddTarget() {
+        deleteBottomsheet.deleteButton.addTarget(self, action: #selector(deletePost), for: .touchUpInside)
+    }
+    
+    @objc
+    func deletePost() {
+        popView()
+        presentView()
+    }
+    
+    func popView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.deleteBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteBottomsheet.frame.width, height: self.deleteBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            deleteBottomsheet.dimView.removeFromSuperview()
+            deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+    }
+    
+    func presentView() {
+        self.present(self.deletePostPopupVC, animated: false, completion: nil)
+    }
+    
+    @objc
+    private func dismissViewController() {
+        self.dismiss(animated: false)
     }
     
     private func setDelegate() {
@@ -115,8 +150,6 @@ extension HomeViewController {
     func finishedRefreshing() {
         refreshControl.endRefreshing()
     }
-    
-    
     
     @objc func showToast(_ notification: Notification) {
         if let showToast = notification.userInfo?["showToast"] as? Bool {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/CancelReplyPopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/CancelReplyPopupViewController.swift
@@ -1,0 +1,82 @@
+//
+//  CancelReplyPopupViewController.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+final class CancelReplyPopupViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let cancelPopupView = DontBePopupView(popupTitle: "",
+                                                  popupContent: StringLiterals.Post.popupReplyContentLabel,
+                                                  leftButtonTitle: StringLiterals.Post.popupReplyCancelButtonTitle,
+                                                  rightButtonTitle: StringLiterals.Post.popupReplyConfirmButtonTitle)
+    
+    private let myView = PostPopupView()
+    private let writeReplyVC = WriteReplyViewController()
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = myView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        getAPI()
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+
+extension CancelReplyPopupViewController {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+        view.addSubviews(cancelPopupView)
+    }
+    
+    private func setLayout() {
+        cancelPopupView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func setDelegate() {
+        cancelPopupView.delegate = self
+    }
+}
+
+// MARK: - Network
+
+extension CancelReplyPopupViewController {
+    private func getAPI() {
+        
+    }
+}
+
+extension CancelReplyPopupViewController: DontBePopupDelegate {
+    func cancleButtonTapped() {
+        self.dismiss(animated: false)
+    }
+
+    func confirmButtonTapped() {
+        self.dismiss(animated: false)
+    }
+}
+

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/CancelReplyPopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/CancelReplyPopupViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class CancelReplyPopupViewController: UIViewController {
     
     // MARK: - Properties
+    static let popViewController = NSNotification.Name("pop")
     
     // MARK: - UI Components
     
@@ -76,6 +77,7 @@ extension CancelReplyPopupViewController: DontBePopupDelegate {
     }
 
     func confirmButtonTapped() {
+        NotificationCenter.default.post(name: CancelReplyPopupViewController.popViewController, object: nil)
         self.dismiss(animated: false)
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -13,7 +13,7 @@ final class PostViewController: UIViewController {
     var tabBarHeight: CGFloat = 0
     private lazy var postUserNickname = postView.postNicknameLabel.text
     private lazy var postDividerView = postView.horizontalDivierView
-    
+
     // MARK: - UI Components
     
     private lazy var myView = PostDetailView()
@@ -115,6 +115,8 @@ extension PostViewController {
     private func setDelegate() {
         postReplyCollectionView.dataSource = self
         postReplyCollectionView.delegate = self
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissViewController), name: CancelReplyPopupViewController.popViewController, object: nil)
     }
     
     @objc
@@ -136,6 +138,11 @@ extension PostViewController {
     private func showReplyVC() {
         let navigationController = UINavigationController(rootViewController: WriteReplyViewController())
         present(navigationController, animated: true, completion: nil)
+    }
+    
+    @objc
+    private func dismissViewController() {
+        self.dismiss(animated: false)
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/TransparentPopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/TransparentPopupViewController.swift
@@ -19,7 +19,7 @@ final class TransparentPopupViewController: UIViewController {
                                                              leftButtonTitle: StringLiterals.Home.transparentPopupLefteftButtonTitle,
                                                              rightButtonTitle: StringLiterals.Home.transparentPopupRightButtonTitle)
     
-    private let myView = ExampleView()
+    private let myView = PostPopupView()
     
     // MARK: - Life Cycles
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/TransparentPopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/TransparentPopupViewController.swift
@@ -1,0 +1,82 @@
+//
+//  TransparentPopupViewController.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+final class TransparentPopupViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let transparentButtonPopupView = DontBePopupView(popupImage: ImageLiterals.Popup.transparentButtonImage,
+                                                             popupTitle: StringLiterals.Home.transparentPopupTitleLabel,
+                                                             popupContent: StringLiterals.Home.transparentPopupContentLabel,
+                                                             leftButtonTitle: StringLiterals.Home.transparentPopupLefteftButtonTitle,
+                                                             rightButtonTitle: StringLiterals.Home.transparentPopupRightButtonTitle)
+    
+    private let myView = ExampleView()
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = myView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        getAPI()
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+
+extension TransparentPopupViewController {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+        view.addSubviews(transparentButtonPopupView)
+    }
+    
+    private func setLayout() {
+        transparentButtonPopupView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func setDelegate() {
+        transparentButtonPopupView.delegate = self
+    }
+}
+
+// MARK: - Network
+
+extension TransparentPopupViewController {
+    private func getAPI() {
+        
+    }
+}
+
+extension TransparentPopupViewController: DontBePopupDelegate {
+    func cancleButtonTapped() {
+        self.dismiss(animated: false)
+    }
+    
+    func confirmButtonTapped() {
+        self.dismiss(animated: false)
+        // ✅ 투명도 주기 버튼 클릭 시 액션 추가
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -11,6 +11,8 @@ final class WriteReplyViewController: UIViewController {
     
     // MARK: - Properties
     
+    static let showUploadToastNotification = Notification.Name("ShowUploadToastNotification")
+    
     // MARK: - UI Components
     
     private let writeView = WriteReplyView()
@@ -63,9 +65,14 @@ extension WriteReplyViewController {
         writeView.writeReplyView.postButton.addTarget(self, action: #selector(postButtonTapped), for: .touchUpInside)
     }
     
+    private func sendData() {
+        NotificationCenter.default.post(name: WriteViewController.showUploadToastNotification, object: nil, userInfo: ["showToast": true])
+    }
+    
     @objc
     func postButtonTapped() {
         popupNavigation()
+        sendData()
     }
 
     private func popupNavigation() {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -13,7 +13,7 @@ final class WriteReplyViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private let myView = WriteReplyView()
+    private let writeView = WriteReplyView()
     private lazy var cancelReplyPopupVC = CancelReplyPopupViewController()
     
     // MARK: - Life Cycles
@@ -21,7 +21,7 @@ final class WriteReplyViewController: UIViewController {
     override func loadView() {
         super.loadView()
         
-        view = myView
+        view = writeView
     }
     
     override func viewDidLoad() {
@@ -34,6 +34,7 @@ final class WriteReplyViewController: UIViewController {
         setDelegate()
         setBottomSheet()
         setNavigationBarButtonItem()
+        setAddTarget()
     }
 }
 
@@ -41,7 +42,7 @@ final class WriteReplyViewController: UIViewController {
 
 extension WriteReplyViewController {
     private func setUI() {
-        myView.backgroundColor = .donWhite
+        writeView.backgroundColor = .donWhite
         title = "답글달기"
         cancelReplyPopupVC.modalPresentationStyle = .overFullScreen
     }
@@ -58,14 +59,27 @@ extension WriteReplyViewController {
         
     }
     
+    private func setAddTarget() {
+        writeView.writeReplyView.postButton.addTarget(self, action: #selector(postButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    func postButtonTapped() {
+        popupNavigation()
+    }
+
+    private func popupNavigation() {
+        self.dismiss(animated: true)
+    }
+    
     private func setBottomSheet() {
         /// 밑으로 내려도 dismiss되지 않는 옵션 값
         isModalInPresentation = true
         
         if let sheet = sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
+            sheet.detents = [.large()]
             sheet.selectedDetentIdentifier = .large
-            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.largestUndimmedDetentIdentifier = .large
             sheet.prefersScrollingExpandsWhenScrolledToEdge = true
             sheet.prefersGrabberVisible = false
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -14,6 +14,7 @@ final class WriteReplyViewController: UIViewController {
     // MARK: - UI Components
     
     private let myView = WriteReplyView()
+    private lazy var cancelReplyPopupVC = CancelReplyPopupViewController()
     
     // MARK: - Life Cycles
     
@@ -42,6 +43,7 @@ extension WriteReplyViewController {
     private func setUI() {
         myView.backgroundColor = .donWhite
         title = "답글달기"
+        cancelReplyPopupVC.modalPresentationStyle = .overFullScreen
     }
     
     private func setHierarchy() {
@@ -70,8 +72,8 @@ extension WriteReplyViewController {
     }
     
     private func setNavigationBarButtonItem() {
-        let cancelButton = UIBarButtonItem(title: "취소", primaryAction: .init(handler: { [weak self] _Arg in
-            self?.dismiss(animated: true)
+        let cancelButton = UIBarButtonItem(title: "취소", primaryAction: .init(handler: { _Arg in
+            self.present(self.cancelReplyPopupVC, animated: false, completion: nil)
         }))
         navigationItem.leftBarButtonItem = cancelButton
         let attributes: [NSAttributedString.Key: Any] = [
@@ -80,6 +82,10 @@ extension WriteReplyViewController {
             ]
         cancelButton.setTitleTextAttributes(attributes, for: .normal)
         cancelButton.setTitleTextAttributes(attributes, for: .highlighted)
+    }
+    
+    public func dismissView() {
+        self.dismiss(animated: true)
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostPopupView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostPopupView.swift
@@ -1,0 +1,62 @@
+//
+//  PostPopupView.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/14/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class PostPopupView: UIView {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension PostPopupView {
+    private func setUI() {
+        
+    }
+    
+    private func setHierarchy() {
+
+    }
+    
+    private func setLayout() {
+
+    }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setRegisterCell() {
+        
+    }
+    
+    private func setDataBind() {
+        
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
@@ -13,9 +13,7 @@ final class PostView: UIView {
 
     // MARK: - Properties
     
-    var KebabButtonAction: (() -> Void) = {}
-    var LikeButtonAction: (() -> Void) = {}
-    var TransparentButtonAction: (() -> Void) = {}
+    var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     var isLiked: Bool = false
     
     // MARK: - UI Components
@@ -128,7 +126,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private let ghostButton: UIButton = {
+    let ghostButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Posting.btnTransparent, for: .normal)
         return button
@@ -272,21 +270,18 @@ extension PostView {
     func setAddTarget() {
         kebabButton.addTarget(self, action: #selector(showButtons), for: .touchUpInside)
         likeButton.addTarget(self, action: #selector(likeToggleButton), for: .touchUpInside)
-        ghostButton.addTarget(self, action: #selector(transparentShowPopupButton), for: .touchUpInside)
     }
     
     @objc
     func showButtons() {
-        KebabButtonAction()
+        self.deleteBottomsheet.showSettings()
     }
     
     @objc
     func likeToggleButton() {
-        LikeButtonAction()
-    }
-    @objc
-    func transparentShowPopupButton() {
-        TransparentButtonAction()
+        isLiked.toggle()
+                likeButton.setImage(isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
+
     }
     
     private func setRegisterCell() {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
@@ -79,7 +79,7 @@ final class WriteReplyEditorView: UIView {
         return circle
     }()
     
-    private let postButton: UIButton = {
+    let postButton: UIButton = {
         let button = UIButton()
         button.setTitle(StringLiterals.Write.writePostButtonTitle, for: .normal)
         button.setTitleColor(.donGray9, for: .normal)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
@@ -15,8 +15,8 @@ final class WriteReplyView: UIView {
     
     // MARK: - UI Components
     
-    private lazy var writeReplyPostview = WriteReplyPostView()
-    private lazy var writeReplyView = WriteReplyEditorView()
+    public lazy var writeReplyPostview = WriteReplyPostView()
+    public lazy var writeReplyView = WriteReplyEditorView()
     
     // MARK: - Life Cycles
     


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->

> 자잘한 버그 수정 및 액션 추가했습니다

1.  투명도 버튼 present로 수정
2.  답글쓰기 취소 팝업
3.  답글 업로드 토스트
4.  신고하기 팝업
5.  게시글 상세 뷰에 있는 버튼들에 action 추가

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
- 대표로 1개만 첨부합니다

|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/71dfcb23-66d0-4866-b436-6249500618ae" width="200">|

## 📟 관련 이슈
- Resolved: #58
