### PR TITLE
Network [#64] 마이페이지 계정 정보 API 구현 완료

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -99,8 +99,11 @@
 		3C6193172B3A7A7B00220CEB /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193162B3A7A7B00220CEB /* UIStackView+.swift */; };
 		3C6193192B3A7AC700220CEB /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193182B3A7AC700220CEB /* Config.swift */; };
 		3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C61931A2B3A7AD000220CEB /* NetworkError.swift */; };
+		3C70BE302B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */; };
+		3C70BE332B53EF92001AA5A6 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */; };
 		3C7741522B5311750069E694 /* MyPageAccountInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */; };
 		3C7741542B531AC80069E694 /* AccountInfoDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741532B531AC80069E694 /* AccountInfoDummy.swift */; };
+		3CD25D272B5466DB0075F80F /* EmptyBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD25D262B5466DB0075F80F /* EmptyBody.swift */; };
 		3CE9C12A2B4BE6780086E4A3 /* WriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C1292B4BE6780086E4A3 /* WriteViewController.swift */; };
 		3CE9C12C2B4BE7300086E4A3 /* WriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C12B2B4BE7300086E4A3 /* WriteView.swift */; };
 		3CE9C12E2B4C08AE0086E4A3 /* WriteTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE9C12D2B4C08AE0086E4A3 /* WriteTextView.swift */; };
@@ -209,8 +212,11 @@
 		3C6193162B3A7A7B00220CEB /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3C6193182B3A7AC700220CEB /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		3C61931A2B3A7AD000220CEB /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMemberDataResponseDTO.swift; sourceTree = "<group>"; };
+		3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAccountInfoTableViewCell.swift; sourceTree = "<group>"; };
 		3C7741532B531AC80069E694 /* AccountInfoDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoDummy.swift; sourceTree = "<group>"; };
+		3CD25D262B5466DB0075F80F /* EmptyBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyBody.swift; sourceTree = "<group>"; };
 		3CE9C1292B4BE6780086E4A3 /* WriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteViewController.swift; sourceTree = "<group>"; };
 		3CE9C12B2B4BE7300086E4A3 /* WriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteView.swift; sourceTree = "<group>"; };
 		3CE9C12D2B4C08AE0086E4A3 /* WriteTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTextView.swift; sourceTree = "<group>"; };
@@ -546,6 +552,7 @@
 			isa = PBXGroup;
 			children = (
 				2A28453C2B531DAD0023F9B5 /* SocialLogin */,
+				3C70BE2A2B53EB81001AA5A6 /* MyPage */,
 				3C61930E2B3A787000220CEB /* Foundation */,
 			);
 			path = Network;
@@ -628,6 +635,7 @@
 				2A28453F2B531F0A0023F9B5 /* BaseResponse.swift */,
 				2A0A73092B541555004478C1 /* HttpMethod.swift */,
 				2A0A730D2B5438B5004478C1 /* KeychainWrapper.swift */,
+				3CD25D262B5466DB0075F80F /* EmptyBody.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -676,6 +684,30 @@
 				2F8735472B4C355100E55552 /* HomeCollectionViewCell.swift */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		3C70BE2A2B53EB81001AA5A6 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				3C70BE2C2B53EB92001AA5A6 /* DTO */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		3C70BE2C2B53EB92001AA5A6 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3C70BE312B53EF7A001AA5A6 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		3C8A262D2B5194C100E549F3 /* Cells */ = {
@@ -745,6 +777,7 @@
 			children = (
 				3CF184C82B4EEBEA00816D5F /* Views */,
 				3CF184C92B4EEBF500816D5F /* ViewControllers */,
+				3C70BE312B53EF7A001AA5A6 /* ViewModels */,
 				3C8A262D2B5194C100E549F3 /* Cells */,
 				3CEE4CBE2B500BA900F506AF /* Helpers */,
 			);
@@ -864,6 +897,7 @@
 				2A8D70BD2B4D61A1009F4C6C /* OnboardingDummy.swift in Sources */,
 				3C6193152B3A7A6400220CEB /* UIView+.swift in Sources */,
 				2AC9FB1F2B4E634A00D31071 /* JoinAgreeView.swift in Sources */,
+				3CD25D272B5466DB0075F80F /* EmptyBody.swift in Sources */,
 				2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */,
 				3C2F544E2B50F65500E7BF01 /* DontBeBottomSheetView.swift in Sources */,
 				3C61930C2B3A782100220CEB /* StringLiterals.swift in Sources */,
@@ -887,6 +921,7 @@
 				3C6193192B3A7AC700220CEB /* Config.swift in Sources */,
 				3CF184D12B4EFF9900816D5F /* MyPageProfileView.swift in Sources */,
 				3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */,
+				3C70BE332B53EF92001AA5A6 /* MyPageViewModel.swift in Sources */,
 				3CE9C12C2B4BE7300086E4A3 /* WriteView.swift in Sources */,
 				3C2F54502B51223200E7BF01 /* MyPageEditProfileViewController.swift in Sources */,
 				2A6D54C32B493A8400F9891E /* UIFont+.swift in Sources */,
@@ -922,6 +957,7 @@
 				2A8D70BF2B4D68E3009F4C6C /* OnboardingEndingViewController.swift in Sources */,
 				2A31FF572B4F1E0400FEEED9 /* String+.swift in Sources */,
 				2A51AE852B4B05AA00FF770A /* SplashViewController.swift in Sources */,
+				3C70BE302B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift in Sources */,
 				2A8D70C32B4D7FF5009F4C6C /* BackButton.swift in Sources */,
 				2A8D70D32B4DD360009F4C6C /* JoinAgreeViewModel.swift in Sources */,
 				3C2855012B3AA0A000369C99 /* ExampleCollectionViewCell.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Network/Foundation/EmptyBody.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/Foundation/EmptyBody.swift
@@ -1,0 +1,12 @@
+//
+//  EmptyBody.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/15/24.
+//
+
+import Foundation
+
+struct EmptyBody: Encodable {
+    
+}

--- a/DontBe-iOS/DontBe-iOS/Network/Foundation/NetworkService.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/Foundation/NetworkService.swift
@@ -36,12 +36,16 @@ final class NetworkService: NetworkServiceType {
             request.addValue($0.value, forHTTPHeaderField: $0.key)
         }
         
-        // 리퀘스트 바디 설정 (구조체)
-        do {
-            let jsonData = try JSONEncoder().encode(body)
-            request.httpBody = jsonData
-        } catch {
-            print("Failed to encode request body: \(error)")
+        if type == .get {
+            request.httpBody = nil
+        } else {
+            // 리퀘스트 바디 설정 (구조체)
+            do {
+                let jsonData = try JSONEncoder().encode(body)
+                request.httpBody = jsonData
+            } catch {
+                print("Failed to encode request body: \(error)")
+            }
         }
         
         return request

--- a/DontBe-iOS/DontBe-iOS/Network/MyPage/DTO/MyPageMemberDataResponseDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/MyPage/DTO/MyPageMemberDataResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  MyPageMemberDataResponseDTO.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/14/24.
+//
+
+import Foundation
+
+// MARK: - MyPageMemberDataResponseDTO
+struct MyPageMemberDataResponseDTO: Decodable {
+    let memberId: Int
+    let joinDate: String
+    let showMemberId: String?
+    let socialPlatform: String
+    let versionInformation: String
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -146,7 +146,7 @@ extension MyPageViewController {
     @objc
     private func accountInfoButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
-        let vc = MyPageAccountInfoViewController()
+        let vc = MyPageAccountInfoViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -1,0 +1,81 @@
+//
+//  MyPageMemberDataViewModel.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/14/24.
+//
+
+import Combine
+import Foundation
+
+final class MyPageViewModel: ViewModelType {
+    
+    private let cancelBag = CancelBag()
+    private let networkProvider: NetworkServiceType
+    private var getData = PassthroughSubject<Void, Never>()
+    
+    var myPageMemberData: [String] = []
+    
+    struct Input {
+        let viewUpdate: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let getData: PassthroughSubject<Void, Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.viewUpdate
+            .sink { _ in
+                Task {
+                    do {
+                        if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
+                            let result = try await self.getMyPageMemberData(accessToken: accessToken)
+                            if let data = result?.data {
+                                self.myPageMemberData = [data.socialPlatform, data.versionInformation, data.showMemberId ?? "money_rain_is_coming", data.joinDate]
+                                self.getData.send()
+                            }
+                        }
+                    } catch {
+                        print(error)
+                    }
+                }
+            }
+            .store(in: self.cancelBag)
+        
+        return Output(getData: getData)
+    }
+    
+    init(networkProvider: NetworkServiceType) {
+        self.networkProvider = networkProvider
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension MyPageViewModel {
+    private func getMyPageMemberData(accessToken: String) async throws -> BaseResponse<MyPageMemberDataResponseDTO>? {
+        let accessToken = accessToken
+        do {
+            let result: BaseResponse<MyPageMemberDataResponseDTO>? = try await self.networkProvider.donNetwork(
+                type: .get,
+                baseURL: Config.baseURL + "/member-data",
+                accessToken: accessToken,
+                body: EmptyBody(),
+                pathVariables: ["":""])
+            
+            if let data = result?.data {
+                let memberData = MyPageMemberDataResponseDTO(memberId: data.memberId,
+                                                             joinDate: data.joinDate,
+                                                             showMemberId: data.showMemberId,
+                                                             socialPlatform: data.socialPlatform,
+                                                             versionInformation: data.versionInformation)
+            }
+            return result
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 마이페이지 계정 정보 API 구현 완료했습니다~!!

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- GET 통신할 땐, requestBody가 필요가 없어서 빈 구조체를 만들어두었습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/45b53752a6f134bc5f3b3b89096ac95ced8ecf7a/DontBe-iOS/DontBe-iOS/Network/Foundation/EmptyBody.swift#L8-L12

- NetworkService 함수 안에 GET 인 경우, nil로 분기 처리를 해놨습니다!
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/45b53752a6f134bc5f3b3b89096ac95ced8ecf7a/DontBe-iOS/DontBe-iOS/Network/Foundation/NetworkService.swift#L39-L49

- NetworkService 함수를 사용할 때, GET 통신을 할 때, 아래와 같이 빈 구조체 사용해주시면 됩니다!
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/45b53752a6f134bc5f3b3b89096ac95ced8ecf7a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift#L58-L81

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/5cce0bde-9aa6-41c8-adb5-53936549f78d" width ="250">|


## 📟 관련 이슈
- Resolved: #64 
