### PR TITLE
Network [#80] 유저에 해당하는 게시글 리스트 조회 API 구현 완료

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		3C6193172B3A7A7B00220CEB /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193162B3A7A7B00220CEB /* UIStackView+.swift */; };
 		3C6193192B3A7AC700220CEB /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6193182B3A7AC700220CEB /* Config.swift */; };
 		3C61931B2B3A7AD000220CEB /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C61931A2B3A7AD000220CEB /* NetworkError.swift */; };
+		3C61C9FC2B56EE50006F1D24 /* MyPageUserContentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C61C9FB2B56EE50006F1D24 /* MyPageUserContentResponseDTO.swift */; };
 		3C70BE302B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */; };
 		3C70BE332B53EF92001AA5A6 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */; };
 		3C7741522B5311750069E694 /* MyPageAccountInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */; };
@@ -232,6 +233,7 @@
 		3C6193162B3A7A7B00220CEB /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3C6193182B3A7AC700220CEB /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		3C61931A2B3A7AD000220CEB /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		3C61C9FB2B56EE50006F1D24 /* MyPageUserContentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageUserContentResponseDTO.swift; sourceTree = "<group>"; };
 		3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMemberDataResponseDTO.swift; sourceTree = "<group>"; };
 		3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAccountInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -796,6 +798,7 @@
 			children = (
 				3C70BE2F2B53EC06001AA5A6 /* MyPageMemberDataResponseDTO.swift */,
 				3CBF99282B56BD210015FE4B /* MypageProfileResponseDTO.swift */,
+				3C61C9FB2B56EE50006F1D24 /* MyPageUserContentResponseDTO.swift */,
 			);
 			path = ResponseDTO;
 			sourceTree = "<group>";
@@ -1161,6 +1164,7 @@
 				3C4993672B4F2644002A99CF /* MyPageContentViewController.swift in Sources */,
 				3CEE4CC22B503F9E00F506AF /* DontBeCustomInfoView.swift in Sources */,
 				2A2845402B531F0A0023F9B5 /* BaseResponse.swift in Sources */,
+				3C61C9FC2B56EE50006F1D24 /* MyPageUserContentResponseDTO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DontBe-iOS/DontBe-iOS/Global/Extension/String+.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Extension/String+.swift
@@ -5,6 +5,8 @@
 //  Created by 변희주 on 1/11/24.
 //
 
+import Foundation
+
 extension String {
     // 글자가 자음인지 체크
     var isConsonant: Bool {
@@ -13,5 +15,34 @@ extension String {
         }
         let consonantScalarRange: ClosedRange<UInt32> = 12593...12622
         return consonantScalarRange ~= scalar
+    }
+    
+    func formattedTime() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        
+        if let postDate = dateFormatter.date(from: self) {
+            let components = Calendar.current.dateComponents([.year, .month, .weekOfYear, .day, .hour, .minute], from: postDate, to: Date())
+            
+            if let year = components.year, year > 0 {
+                return "\(year)년 전"
+            } else if let month = components.month, month > 0 {
+                return "\(month)개월 전"
+            } else if let week = components.weekOfYear, week > 0 {
+                return "\(week)주 전"
+            } else if let day = components.day, day > 0 {
+                return "\(day)일 전"
+            } else if let hour = components.hour, hour > 0 {
+                return "\(hour)시간 전"
+            } else if let minute = components.minute, minute == 0 {
+                return "지금"
+            } else if let minute = components.minute, minute > 0 {
+                return "\(minute)분 전"
+            } else {
+                return "시간을 불러올 수 없습니다."
+            }
+        } else {
+            return "날짜 변환 실패"
+        }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Network/MyPage/DTO/ResponseDTO/MyPageUserContentResponseDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/MyPage/DTO/ResponseDTO/MyPageUserContentResponseDTO.swift
@@ -1,0 +1,24 @@
+//
+//  MyPageUserContentResponseDTO.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 1/17/24.
+//
+
+import Foundation
+
+// MARK: - MyPageUserContentResponseDTO
+
+struct MyPageUserContentResponseDTO: Decodable {
+    let memberId: Int
+    let memberProfileUrl: String
+    let memberNickname: String
+    let contentId: Int
+    let contentText: String
+    let time: String
+    let isGhost: Bool
+    let memberGhost: Int
+    let isLiked: Bool
+    let likedNumber: Int
+    let commentNumber: Int
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -15,7 +15,7 @@ final class MyPageViewController: UIViewController {
     // MARK: - Properties
     
     private var cancelBag = CancelBag()
-    private let viewModel: MyPageViewModel
+    var viewModel: MyPageViewModel
     
     var currentPage: Int = 0 {
         didSet {
@@ -181,7 +181,7 @@ extension MyPageViewController {
     @objc
     private func accountInfoButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
-        let vc = MyPageAccountInfoViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
+        let vc = MyPageAccountInfoViewController(viewModel: self.viewModel)
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
@@ -71,7 +71,7 @@ final class MyPageView: UIView {
         return vc
     }()
     
-    let myPageContentViewController = MyPageContentViewController()
+    let myPageContentViewController = MyPageContentViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
     let myPageCommentViewController = MyPageCommentViewController()
     
     var myPageBottomsheet = DontBeBottomSheetView(profileEditImage: ImageLiterals.MyPage.btnEditProfile,


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 유저에 해당하는 게시글 리스트 조회 API 구현 완료 했습니다~!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/ce73def3-a634-47d6-b604-10f1a524c576" width ="250">|

## 📟 관련 이슈
- Resolved: #80 
