### PR TITLE
Network [#85] 게시글 상세 조회 API 연결

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		2AF069B42B5194F300CA3E48 /* MyPageIntroductionEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF069B32B5194F300CA3E48 /* MyPageIntroductionEditView.swift */; };
 		2AF069B62B51F0D400CA3E48 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF069B52B51F0D400CA3E48 /* OnboardingView.swift */; };
 		2F05B1A72B5799B700AC368D /* PostDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F05B1A62B5799B700AC368D /* PostDetailResponseDTO.swift */; };
+		2F05B1AA2B579DED00AC368D /* PostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F05B1A92B579DED00AC368D /* PostViewModel.swift */; };
 		2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741872B500C270089FC4D /* UIApplication+.swift */; };
 		2F17418A2B500CC20089FC4D /* HomeBottomsheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */; };
 		2F8735402B4BE65300E55552 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F87353F2B4BE65300E55552 /* HomeView.swift */; };
@@ -187,6 +188,7 @@
 		2AF069B32B5194F300CA3E48 /* MyPageIntroductionEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageIntroductionEditView.swift; sourceTree = "<group>"; };
 		2AF069B52B51F0D400CA3E48 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		2F05B1A62B5799B700AC368D /* PostDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailResponseDTO.swift; sourceTree = "<group>"; };
+		2F05B1A92B579DED00AC368D /* PostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewModel.swift; sourceTree = "<group>"; };
 		2F1741872B500C270089FC4D /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomsheetView.swift; sourceTree = "<group>"; };
 		2F87353F2B4BE65300E55552 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -557,11 +559,20 @@
 			path = ResponseDTO;
 			sourceTree = "<group>";
 		};
+		2F05B1A82B579CEF00AC368D /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				2F05B1A92B579DED00AC368D /* PostViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		2FB818CD2B5168C400B7498F /* Post */ = {
 			isa = PBXGroup;
 			children = (
 				2FB818CF2B5168E100B7498F /* Views */,
 				2FB818CE2B5168D400B7498F /* ViewControllers */,
+				2F05B1A82B579CEF00AC368D /* ViewModel */,
 				2FB818DA2B51873500B7498F /* Cells */,
 			);
 			path = Post;
@@ -1168,6 +1179,7 @@
 				2A2845462B532BCB0023F9B5 /* SocialLoginRequestDTO.swift in Sources */,
 				2AF069B42B5194F300CA3E48 /* MyPageIntroductionEditView.swift in Sources */,
 				2A2672052B4C3C00009D214F /* CancelBag.swift in Sources */,
+				2F05B1AA2B579DED00AC368D /* PostViewModel.swift in Sources */,
 				2FB818D92B5186FC00B7498F /* PostReplyCollectionView.swift in Sources */,
 				2AF069B62B51F0D400CA3E48 /* OnboardingView.swift in Sources */,
 				2A84465A2B4EE8B400F98F2A /* JoinProfileViewController.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		2AF069B22B518F8E00CA3E48 /* MyPageNicknameEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF069B12B518F8E00CA3E48 /* MyPageNicknameEditView.swift */; };
 		2AF069B42B5194F300CA3E48 /* MyPageIntroductionEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF069B32B5194F300CA3E48 /* MyPageIntroductionEditView.swift */; };
 		2AF069B62B51F0D400CA3E48 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF069B52B51F0D400CA3E48 /* OnboardingView.swift */; };
+		2F05B1A72B5799B700AC368D /* PostDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F05B1A62B5799B700AC368D /* PostDetailResponseDTO.swift */; };
 		2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741872B500C270089FC4D /* UIApplication+.swift */; };
 		2F17418A2B500CC20089FC4D /* HomeBottomsheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */; };
 		2F8735402B4BE65300E55552 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F87353F2B4BE65300E55552 /* HomeView.swift */; };
@@ -185,6 +186,7 @@
 		2AF069B12B518F8E00CA3E48 /* MyPageNicknameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageNicknameEditView.swift; sourceTree = "<group>"; };
 		2AF069B32B5194F300CA3E48 /* MyPageIntroductionEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageIntroductionEditView.swift; sourceTree = "<group>"; };
 		2AF069B52B51F0D400CA3E48 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		2F05B1A62B5799B700AC368D /* PostDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailResponseDTO.swift; sourceTree = "<group>"; };
 		2F1741872B500C270089FC4D /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomsheetView.swift; sourceTree = "<group>"; };
 		2F87353F2B4BE65300E55552 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -531,6 +533,30 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		2F05B1A32B57993200AC368D /* Post */ = {
+			isa = PBXGroup;
+			children = (
+				2F05B1A42B57998500AC368D /* DTO */,
+			);
+			path = Post;
+			sourceTree = "<group>";
+		};
+		2F05B1A42B57998500AC368D /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				2F05B1A52B57999A00AC368D /* ResponseDTO */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		2F05B1A52B57999A00AC368D /* ResponseDTO */ = {
+			isa = PBXGroup;
+			children = (
+				2F05B1A62B5799B700AC368D /* PostDetailResponseDTO.swift */,
+			);
+			path = ResponseDTO;
+			sourceTree = "<group>";
+		};
 		2FB818CD2B5168C400B7498F /* Post */ = {
 			isa = PBXGroup;
 			children = (
@@ -653,6 +679,7 @@
 		3C6193022B3A773100220CEB /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				2F05B1A32B57993200AC368D /* Post */,
 				2A5182FD2B569B8600B43BA8 /* UserProfile */,
 				2A0A73132B5486F8004478C1 /* TokenManager */,
 				3CBF991F2B549B470015FE4B /* Write */,
@@ -1060,6 +1087,7 @@
 				3CD25D272B5466DB0075F80F /* Empty.swift in Sources */,
 				2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */,
 				3C2F544E2B50F65500E7BF01 /* DontBeBottomSheetView.swift in Sources */,
+				2F05B1A72B5799B700AC368D /* PostDetailResponseDTO.swift in Sources */,
 				3C61930C2B3A782100220CEB /* StringLiterals.swift in Sources */,
 				2FB64FF22B5318C50082A414 /* WriteReplyPostView.swift in Sources */,
 				2FB818D52B517EE700B7498F /* PostDetailView.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Network/Home/DTO/ResponseDTO/PostDataResponseDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/Home/DTO/ResponseDTO/PostDataResponseDTO.swift
@@ -21,34 +21,4 @@ struct PostDataResponseDTO: Decodable {
     let isLiked: Bool
     let likedNumber: Int
     let commentNumber: Int
-    
-    var formatTime: String {
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        
-        if let postDate = dateFormatter.date(from: time) {
-            let components = Calendar.current.dateComponents([.year, .month, .weekOfYear, .day, .hour, .minute], from: postDate, to: Date())
-            
-            if let year = components.year, year > 0 {
-                return "\(year)년 전"
-            } else if let month = components.month, month > 0 {
-                return "\(month)개월 전"
-            } else if let week = components.weekOfYear, week > 0 {
-                return "\(week)주 전"
-            } else if let day = components.day, day > 0 {
-                return "\(day)일 전"
-            } else if let hour = components.hour, hour > 0 {
-                return "\(hour)시간 전"
-            } else if let minute = components.minute, minute == 0 {
-                return "지금"
-            } else if let minute = components.minute, minute > 0 {
-                return "\(minute)분 전"
-            } else {
-                return "시간을 불러올 수 없습니다."
-            }
-        } else {
-            return "날짜 변환 실패"
-        }
-    }
 }

--- a/DontBe-iOS/DontBe-iOS/Network/Post/DTO/ResponseDTO/PostDetailResponseDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/Post/DTO/ResponseDTO/PostDetailResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  PostDetailResponseDTO.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/17/24.
+//
+
+import Foundation
+
+struct PostDetailResponseDTO: Decodable {
+    let memberId: Int
+    let memberProfileUrl: String
+    let memberNickname: String
+    let isGhost: Bool
+    let memberGhost: Int
+    let isLiked: Bool
+    let time: String
+    let likedNumber: Int
+    let commentNumber: Int
+    let contentText: String
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -5,8 +5,8 @@
 //  Created by yeonsu on 1/8/24.
 //
 
-import UIKit
 import Combine
+import UIKit
 
 import SnapKit
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -6,9 +6,9 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
-import Combine
 
 final class HomeViewController: UIViewController {
     
@@ -23,6 +23,12 @@ final class HomeViewController: UIViewController {
     
     private var cancelBag = CancelBag()
     private let viewModel: HomeViewModel
+    let postViewModel = PostViewModel(networkProvider: NetworkService())
+    
+    
+    let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
+    
+    var contentId: Int = 0
     
     // MARK: - UI Components
     
@@ -228,11 +234,11 @@ extension HomeViewController: UICollectionViewDelegate { }
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         let sortedData = viewModel.postData.sorted {
-                $0.time.compare($1.time, options: .numeric) == .orderedDescending
-            }
-            
-            // Replace the viewModel.postData array with the sortedData
-            viewModel.postData = sortedData
+            $0.time.compare($1.time, options: .numeric) == .orderedDescending
+        }
+        
+        // Replace the viewModel.postData array with the sortedData
+        viewModel.postData = sortedData
         
         return viewModel.postData.count
     }
@@ -258,11 +264,14 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         cell.commentNumLabel.text = "\(viewModel.postData[indexPath.row].commentNumber)"
         cell.timeLabel.text = "\(viewModel.postData[indexPath.row].time.formattedTime())"
         cell.profileImageView.load(url: "\(viewModel.postData[indexPath.row].memberProfileUrl)")
+        
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let destinationViewController = PostViewController()
+
+        self.destinationViewController.contentId = viewModel.postData[indexPath.row].contentId
+        
         self.navigationController?.pushViewController(destinationViewController, animated: true)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -256,7 +256,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         cell.contentTextLabel.text = viewModel.postData[indexPath.row].contentText
         cell.likeNumLabel.text = "\(viewModel.postData[indexPath.row].likedNumber)"
         cell.commentNumLabel.text = "\(viewModel.postData[indexPath.row].commentNumber)"
-        cell.timeLabel.text = "\(viewModel.postData[indexPath.row].formatTime)"
+        cell.timeLabel.text = "\(viewModel.postData[indexPath.row].time.formattedTime())"
         cell.profileImageView.load(url: "\(viewModel.postData[indexPath.row].memberProfileUrl)")
         return cell
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -145,7 +145,7 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let destinationViewController = PostViewController()
+        let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
         self.navigationController?.pushViewController(destinationViewController, animated: true)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewModel/PostViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewModel/PostViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  PostViewModel.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/17/24.
+//
+
+import Foundation
+import Combine
+
+final class PostViewModel: ViewModelType {
+    
+    private let cancelBag = CancelBag()
+    private let networkProvider: NetworkServiceType
+    private var getPostData = PassthroughSubject<PostDetailResponseDTO, Never>()
+    
+    var postDetailData: [String] = []
+    
+    struct Input {
+        let viewUpdate: AnyPublisher<Int, Never>
+    }
+    
+    struct Output {
+        let getPostData: PassthroughSubject<PostDetailResponseDTO, Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.viewUpdate
+            .sink { value in
+                Task {
+                    do {
+                        if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
+                            let postResult = try await
+                            self.getPostDetailDataAPI(accessToken: accessToken, contentId: value)
+                            if let data = postResult?.data {
+                                self.getPostData.send(data)
+                            }
+                        }
+                    } catch {
+                        print(error)
+                    }
+                }
+            }
+            .store(in: self.cancelBag)
+        return Output(getPostData: getPostData)
+    }
+    
+    init(networkProvider: NetworkServiceType) {
+        self.networkProvider = networkProvider
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension PostViewModel {
+    private func getPostDetailDataAPI(accessToken: String, contentId: Int) async throws -> BaseResponse<PostDetailResponseDTO>? {
+        let accessToken = accessToken
+        do {
+            let result: BaseResponse<PostDetailResponseDTO>? = try
+            await self.networkProvider.donNetwork(type: .get, baseURL: Config.baseURL + "/content/\(contentId)/detail", accessToken: accessToken, body: EmptyBody(), pathVariables: ["":""])
+            
+            return result
+        } catch {
+            return nil
+        }
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
@@ -36,7 +36,7 @@ final class PostView: UIView {
     public let postNicknameLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donBlack
-        label.text = "Don't be야 사랑해~"
+        label.text = ""
         label.font = .font(.body3)
         return label
     }()
@@ -44,7 +44,7 @@ final class PostView: UIView {
     let transparentLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray9
-        label.text = "투명도 0%"
+        label.text = ""
         label.font = .font(.caption4)
         return label
     }()
@@ -60,7 +60,7 @@ final class PostView: UIView {
     let timeLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray9
-        label.text = "3분 전"
+        label.text = ""
         label.font = .font(.caption4)
         return label
     }()
@@ -74,7 +74,7 @@ final class PostView: UIView {
     let contentTextLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donBlack
-        label.text = "돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다.돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다."
+        label.text = ""
         label.lineBreakMode = .byCharWrapping
         label.font = .font(.body4)
         label.numberOfLines = 0
@@ -98,7 +98,7 @@ final class PostView: UIView {
     let likeNumLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray11
-        label.text = "54"
+        label.text = ""
         label.font = .font(.caption4)
         return label
     }()
@@ -121,7 +121,7 @@ final class PostView: UIView {
     let commentNumLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray11
-        label.text = "54"
+        label.text = ""
         label.font = .font(.caption4)
         return label
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostView.swift
@@ -24,7 +24,7 @@ final class PostView: UIView {
         return view
     }()
     
-    private let profileImageView: UIImageView = {
+    let profileImageView: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
@@ -41,7 +41,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private let transparentLabel: UILabel = {
+    let transparentLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray9
         label.text = "투명도 0%"
@@ -49,7 +49,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private let dotLabel: UILabel = {
+    let dotLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray9
         label.text = "·"
@@ -57,7 +57,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private let timeLabel: UILabel = {
+    let timeLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray9
         label.text = "3분 전"
@@ -65,13 +65,13 @@ final class PostView: UIView {
         return label
     }()
     
-    private let kebabButton: UIButton = {
+    let kebabButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Posting.btnKebab, for: .normal)
         return button
     }()
     
-    private let contentTextLabel: UILabel = {
+    let contentTextLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donBlack
         label.text = "돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다.돈비를 사용하면 진짜 돈비를 맞을 수 있나요? 저 돈비 맞고 싶어요 돈벼락이 최고입니다."
@@ -81,7 +81,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private lazy var likeStackView: UIStackView = {
+    lazy var likeStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.distribution = .equalSpacing
         stackView.axis = .horizontal
@@ -95,7 +95,7 @@ final class PostView: UIView {
         return button
     }()
     
-    private let likeNumLabel: UILabel = {
+    let likeNumLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray11
         label.text = "54"
@@ -103,7 +103,7 @@ final class PostView: UIView {
         return label
     }()
     
-    private lazy var commentStackView: UIStackView = {
+    lazy var commentStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.addArrangedSubviews(commentButton, commentNumLabel)
         stackView.distribution = .equalSpacing
@@ -112,13 +112,13 @@ final class PostView: UIView {
         return stackView
     }()
     
-    private let commentButton: UIButton = {
+    let commentButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Posting.btnComment, for: .normal)
         return button
     }()
     
-    private let commentNumLabel: UILabel = {
+    let commentNumLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donGray11
         label.text = "54"
@@ -132,7 +132,7 @@ final class PostView: UIView {
         return button
     }()
     
-    private let verticalTextBarView: UIView = {
+    let verticalTextBarView: UIView = {
         let view = UIView()
         view.backgroundColor = .donPale
         return view


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 홈 뷰 게시글 조회에 사용한 Date 변경 포맷을 기존 DTO 파일에서 extension에서 구현한 함수로 변경했습니다.
- 홈 게시글 상세 뷰에 있는 게시글 부분 API 연결했습니다.
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

> 각 cell에 해당하는 contentId를 URL에 포함하는 방법입니다. (홈 뷰 -> 게시글 상세 뷰)
1. HomeVC에서 받아온 데이터 중에 contentId[indexPath.row]의 값을 PostVC로 전달합니다.
`let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))`
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/d38a82c7eabffb555722ccf416f2c871fe79dfbd/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift#L271-L276
2. PostVC에서 Input - Just()에 1번에서 받아온 contentId를 실어 보냅니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/d38a82c7eabffb555722ccf416f2c871fe79dfbd/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift#L271-L282
3. contentId를 매개변수로 받는 함수를 사용하여 URL에 contentId값을 넣어줍니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/d38a82c7eabffb555722ccf416f2c871fe79dfbd/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewModel/PostViewModel.swift#L19-L69
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/5cd38371-611a-4b88-bcac-b60a5bf889a8" width ="250">|\

## 📟 관련 이슈
- Resolved: #85 
