### PR TITLE
Fix [#96] 마이페이지 디테일 수정

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeTransparencyInfoView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeTransparencyInfoView.swift
@@ -85,7 +85,7 @@ extension DontBeTransparencyInfoView {
     
     private func setLayout() {
         container.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(67.adjusted)
+            $0.centerY.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(18.adjusted)
             $0.height.equalTo(392.adjusted)
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -77,7 +77,10 @@ final class HomeViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        tabBarHeight = tabBarController?.tabBar.frame.size.height ?? 0
+        let safeAreaHeight = view.safeAreaInsets.bottom
+        let tabBarHeight: CGFloat = 70.0
+        
+        self.tabBarHeight = tabBarHeight + safeAreaHeight
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -132,21 +132,26 @@ extension MyPageCommentViewController: UICollectionViewDataSource, UICollectionV
         cell.likeNumLabel.text = "\(commentData[indexPath.row].commentLikedNumber)"
         cell.commentNumLabel.text = "\(commentData[indexPath.row].commentLikedNumber)"
         cell.profileImageView.load(url: "\(commentData[indexPath.row].memberProfileUrl)")
+        
+        cell.likeStackView.snp.remakeConstraints {
+            $0.top.equalTo(cell.contentTextLabel.snp.bottom).offset(4.adjusted)
+            $0.height.equalTo(cell.commentStackView)
+            $0.trailing.equalTo(cell.kebabButton).inset(8.adjusted)
+            $0.bottom.equalToSuperview().inset(16)
+        }
+        
+        cell.commentStackView.isHidden = true
+        
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
-        self.navigationController?.pushViewController(destinationViewController, animated: true)
+        let contentId = commentData[indexPath.row].contentId
+        NotificationCenter.default.post(name: MyPageContentViewController.pushViewController, object: nil, userInfo: ["contentId": contentId])
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 343.adjusted, height: 210.adjusted)
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        guard let footer = homeCollectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "HomeCollectionFooterView", for: indexPath) as? HomeCollectionFooterView else { return UICollectionReusableView() }
-        return footer
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -14,6 +14,8 @@ final class MyPageContentViewController: UIViewController {
     
     // MARK: - Properties
     
+    static let pushViewController = NSNotification.Name("pushViewController")
+    
     var showUploadToastView: Bool = false
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     private let refreshControl = UIRefreshControl()
@@ -163,18 +165,13 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
-        self.navigationController?.pushViewController(destinationViewController, animated: true)
+        let contentId = contentData[indexPath.row].contentId
+        NotificationCenter.default.post(name: MyPageContentViewController.pushViewController, object: nil, userInfo: ["contentId": contentId])
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 343.adjusted, height: 210.adjusted)
     }
-    
-//    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-//        guard let footer = homeCollectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "HomeCollectionFooterView", for: indexPath) as? HomeCollectionFooterView else { return UICollectionReusableView() }
-//        return footer
-//    }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -93,7 +93,7 @@ final class MyPageViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         let safeAreaHeight = view.safeAreaInsets.bottom
-        let tabBarHeight: CGFloat = 70.0.adjusted
+        let tabBarHeight: CGFloat = 70.0
         
         self.tabBarHeight = tabBarHeight + safeAreaHeight
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -176,6 +176,9 @@ extension MyPageViewController {
             .receive(on: RunLoop.main)
             .sink { data in
                 self.rootView.myPageCommentViewController.commentData = data
+                if !data.isEmpty {
+                    self.rootView.myPageCommentViewController.noCommentLabel.isHidden = true
+                }
                 self.rootView.myPageCommentViewController.homeCollectionView.reloadData()
             }
             .store(in: self.cancelBag)

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -69,6 +69,7 @@ final class MyPageViewController: UIViewController {
         setUI()
         setLayout()
         setDelegate()
+        setNotification()
         setAddTarget()
     }
     
@@ -138,6 +139,10 @@ extension MyPageViewController {
         rootView.pageViewController.dataSource = self
     }
     
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(pushViewController), name: MyPageContentViewController.pushViewController, object: nil)
+    }
+    
     private func setAddTarget() {
         rootView.segmentedControl.addTarget(self, action: #selector(changeValue(control:)), for: .valueChanged)
         rootView.myPageBottomsheet.profileEditButton.addTarget(self, action: #selector(profileEditButtonTapped), for: .touchUpInside)
@@ -197,6 +202,15 @@ extension MyPageViewController {
         } else {
             self.rootView.myPageContentViewController.noContentLabel.text = "\(data.nickname)" + StringLiterals.MyPage.myPageNoContentLabel
             self.rootView.myPageCommentViewController.noCommentLabel.text = StringLiterals.MyPage.myPageNoCommentLabel
+        }
+    }
+    
+    @objc
+    private func pushViewController(_ notification: Notification) {
+        if let contentId = notification.userInfo?["contentId"] as? Int {
+            let destinationViewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
+            destinationViewController.contentId = contentId
+            self.navigationController?.pushViewController(destinationViewController, animated: true)
         }
     }
     
@@ -303,15 +317,11 @@ extension MyPageViewController: UICollectionViewDelegate {
         
         scrollView.isScrollEnabled = true
         rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = false
-        rootView.myPageContentViewController.homeCollectionView.isUserInteractionEnabled = false
         rootView.myPageCommentViewController.homeCollectionView.isScrollEnabled = false
-        rootView.myPageCommentViewController.homeCollectionView.isUserInteractionEnabled = false
         
         if yOffset <= -(navigationBarHeight + statusBarHeight) {
             rootView.myPageContentViewController.homeCollectionView.isScrollEnabled = false
-            rootView.myPageContentViewController.homeCollectionView.isUserInteractionEnabled = false
             rootView.myPageCommentViewController.homeCollectionView.isScrollEnabled = false
-            rootView.myPageCommentViewController.homeCollectionView.isUserInteractionEnabled = false
             yOffset = -(navigationBarHeight + statusBarHeight)
             rootView.segmentedControl.frame.origin.y = yOffset + statusBarHeight + navigationBarHeight
             rootView.segmentedControl.snp.remakeConstraints {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
@@ -158,16 +158,20 @@ extension MyPageView {
     private func infoButtonTapped() {
         self.myPageScrollView.isScrollEnabled = false
         
-        transparencyInfoView = DontBeTransparencyInfoView()
-        self.addSubview(transparencyInfoView ?? DontBeTransparencyInfoView())
+        self.transparencyInfoView = DontBeTransparencyInfoView()
         
-        transparencyInfoView?.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+        if let window = UIApplication.shared.keyWindowInConnectedScenes {
+            window.addSubview(transparencyInfoView ?? DontBeTransparencyInfoView())
         }
         
-        transparencyInfoView?.bringSubviewToFront(self)
-        transparencyInfoView?.closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
-        transparencyInfoView?.infoScrollView.delegate = self
+        self.transparencyInfoView?.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(UIScreen.main.bounds.height)
+        }
+        
+        self.transparencyInfoView?.bringSubviewToFront(self)
+        self.transparencyInfoView?.closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        self.transparencyInfoView?.infoScrollView.delegate = self
     }
     
     @objc

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -11,6 +11,7 @@ import Combine
 final class PostViewController: UIViewController {
     
     // MARK: - Properties
+    
     var tabBarHeight: CGFloat = 0
     private lazy var postUserNickname = postView.postNicknameLabel.text
     private lazy var postDividerView = postView.horizontalDivierView
@@ -80,7 +81,10 @@ final class PostViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        tabBarHeight = tabBarController?.tabBar.frame.size.height ?? 0
+        let safeAreaHeight = view.safeAreaInsets.bottom
+        let tabBarHeight: CGFloat = 70.0
+        
+        self.tabBarHeight = tabBarHeight + safeAreaHeight
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -92,7 +96,11 @@ final class PostViewController: UIViewController {
         
         let backButton = UIBarButtonItem.backButton(target: self, action: #selector(backButtonPressed))
         self.navigationItem.leftBarButtonItem = backButton
-        
+//        self.textFieldView.snp.remakeConstraints {
+//            $0.leading.trailing.equalToSuperview()
+//            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-tabBarHeight)
+//            $0.height.equalTo(56.adjusted)
+//        }
         getAPI()
     }
 }
@@ -136,7 +144,7 @@ extension PostViewController {
         }
         
         textFieldView.snp.makeConstraints {
-            $0.bottom.equalTo(tabBarHeight.adjusted)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-tabBarHeight)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56.adjusted)
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -22,7 +22,7 @@ final class WriteReplyViewController: UIViewController {
     }.eraseToAnyPublisher()
     
     var contentId: Int = 0
-    
+    var tabBarHeight: CGFloat = 0
     
     // MARK: - UI Components
     
@@ -60,6 +60,15 @@ final class WriteReplyViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         bindViewModel()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let safeAreaHeight = view.safeAreaInsets.bottom
+        let tabBarHeight: CGFloat = 70.0
+        
+        self.tabBarHeight = tabBarHeight + safeAreaHeight
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -149,7 +149,7 @@ extension WriteTextView {
         keyboardToolbarView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56.adjusted)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
         }
         
         circleProgressBar.snp.makeConstraints {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 마이페이지 투명도 정보 뷰 UI 레이아웃 수정했습니다!
- 마이페이지에서 해당 게시글로 이동하도록 코드 추가했습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/1f18d310-e1d0-44ef-8b7e-cb6ba16b1bd9" width ="250">|

## 📟 관련 이슈
- Resolved: #96 
