### PR TITLE
Feat [#109] 마이페이지 게시글, 답글에 좋아요 액션, 게시물 삭제 액션 추가

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -32,6 +32,7 @@ final class HomeViewController: UIViewController {
     var alarmTriggerdId: Int = 0
     
     let warnUserURL = NSURL(string: "\(StringLiterals.Network.warnUserGoogleFormURL)")
+    
     // MARK: - UI Components
     
     private let myView = HomeView()
@@ -166,10 +167,10 @@ extension HomeViewController {
     }
     
     @objc func didDismissPopupNotification(_ notification: Notification) {
-          DispatchQueue.main.async {
-              self.refreshPost()
-          }
-      }
+        DispatchQueue.main.async {
+            self.refreshPost()
+        }
+    }
     
     private func setRefreshControll() {
         refreshControl.addTarget(self, action: #selector(refreshPost), for: .valueChanged)
@@ -319,9 +320,11 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell =
         HomeCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
+        
         cell.alarmTriggerType = "contentGhost"
         cell.targetMemberId = viewModel.postData[indexPath.row].memberId
         cell.alarmTriggerdId = viewModel.postData[indexPath.row].contentId
+        
         if viewModel.postData[indexPath.row].memberId == loadUserData()?.memberId {
             cell.ghostButton.isHidden = true
             cell.verticalTextBarView.isHidden = true
@@ -383,6 +386,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
             self.alarmTriggerdId = cell.alarmTriggerdId
             self.present(self.transparentPopupVC, animated: false, completion: nil)
         }
+        
         cell.profileImageView.load(url: viewModel.postData[indexPath.row].memberProfileUrl)
         cell.nicknameLabel.text = viewModel.postData[indexPath.row].memberNickname
         cell.transparentLabel.text = "투명도 \(viewModel.postData[indexPath.row].memberGhost)%"

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-final class MyPageAccountInfoViewController: UIViewController, UIGestureRecognizerDelegate {
+final class MyPageAccountInfoViewController: UIViewController {
     
     // MARK: - Properties
     
@@ -99,6 +99,8 @@ final class MyPageAccountInfoViewController: UIViewController, UIGestureRecogniz
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .clear
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
+        self.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isTranslucent = true
         
         let backButton = UIBarButtonItem.backButton(target: self, action: #selector(backButtonTapped))
         self.navigationItem.leftBarButtonItem = backButton
@@ -109,7 +111,7 @@ final class MyPageAccountInfoViewController: UIViewController, UIGestureRecogniz
 
 extension MyPageAccountInfoViewController {
     private func setUI() {
-        self.title = "계정 정보"
+        self.title = StringLiterals.MyPage.MyPageAccountInfoNavigationTitle
         self.view.backgroundColor = .donWhite
         
         self.navigationController?.navigationBar.backgroundColor = .donWhite

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import SafariServices
 import UIKit
 
 import SnapKit
@@ -15,15 +16,23 @@ final class MyPageContentViewController: UIViewController {
     // MARK: - Properties
     
     static let pushViewController = NSNotification.Name("pushViewController")
+    static let reloadData = NSNotification.Name("reloadData")
+    static let warnUserButtonTapped = NSNotification.Name("warnUserButtonTapped")
     
     var showUploadToastView: Bool = false
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
     private let refreshControl = UIRefreshControl()
     
+    private let viewModel: HomeViewModel
     private var cancelBag = CancelBag()
     
     var profileData: [MypageProfileResponseDTO] = []
     var contentData: [MyPageMemberContentResponseDTO] = []
+    
+    var contentId: Int = 0
+    var alarmTriggerType: String = ""
+    var targetMemberId: Int = 0
+    var alarmTriggerdId: Int = 0
     
     // MARK: - UI Components
     
@@ -50,23 +59,28 @@ final class MyPageContentViewController: UIViewController {
         return button
     }()
     
+    var deletePostPopupVC = DeletePopupViewController(viewModel: DeletePostViewModel(networkProvider: NetworkService()))
+    var warnBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnWarn)
+    
     // MARK: - Life Cycles
+    
+    init(viewModel: HomeViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        getAPI()
         setUI()
         setHierarchy()
         setLayout()
         setDelegate()
         setRefreshControll()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(true)
-        
-        
     }
 }
 
@@ -76,6 +90,8 @@ extension MyPageContentViewController {
     private func setUI() {
         self.view.backgroundColor = UIColor.donGray1
         self.navigationController?.navigationBar.isHidden = true
+        
+        deletePostPopupVC.modalPresentationStyle = .overFullScreen
     }
     
     private func setHierarchy() {
@@ -123,13 +139,51 @@ extension MyPageContentViewController {
     func finishedRefreshing() {
         refreshControl.endRefreshing()
     }
-}
+    
+    @objc
+    private func deleteButtonTapped() {
+        popView()
+        presentView()
+    }
+    
+    @objc
+    private func warnButtonTapped() {
+        NotificationCenter.default.post(name: MyPageContentViewController.warnUserButtonTapped, object: nil)
+    }
+    
+    func popView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.deleteBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteBottomsheet.frame.width, height: self.deleteBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            deleteBottomsheet.dimView.removeFromSuperview()
+            deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+        refreshPost()
+    }
+    
+    func presentView() {
+        deletePostPopupVC.contentId = self.contentId
+        self.present(self.deletePostPopupVC, animated: false, completion: nil)
+    }
+    
+    private func postLikeButtonAPI(isClicked: Bool, contentId: Int) {
+        // 최초 한 번만 publisher 생성
+        let likeButtonTapped: AnyPublisher<(Bool, Int), Never>?  = Just(())
+                .map { _ in return (!isClicked, contentId) }
+                .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
+                .eraseToAnyPublisher()
 
-// MARK: - Network
+        let input = HomeViewModel.Input(viewUpdate: nil, likeButtonTapped: likeButtonTapped)
 
-extension MyPageContentViewController {
-    private func getAPI() {
-        
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+
+        output.toggleLikeButton
+            .sink { _ in }
+            .store(in: self.cancelBag)
     }
 }
 
@@ -147,13 +201,72 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
         let cell =
         HomeCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
         
+        cell.alarmTriggerType = "contentGhost"
+        cell.targetMemberId = contentData[indexPath.row].memberId
+        cell.alarmTriggerdId = contentData[indexPath.row].contentId
+        
         if contentData[indexPath.row].memberId == loadUserData()?.memberId {
             cell.ghostButton.isHidden = true
             cell.verticalTextBarView.isHidden = true
+            self.deleteBottomsheet.warnButton.removeFromSuperview()
+            
+            cell.KebabButtonAction = {
+                self.deleteBottomsheet.showSettings()
+                self.deleteBottomsheet.deleteButton.addTarget(self, action: #selector(self.deleteButtonTapped), for: .touchUpInside)
+                self.contentId = self.contentData[indexPath.row].contentId
+            }
         } else {
             cell.ghostButton.isHidden = false
             cell.verticalTextBarView.isHidden = false
+            self.warnBottomsheet.deleteButton.removeFromSuperview()
+            
+            cell.KebabButtonAction = {
+                self.warnBottomsheet.showSettings()
+                self.warnBottomsheet.warnButton.addTarget(self, action: #selector(self.warnButtonTapped), for: .touchUpInside)
+                self.contentId = self.contentData[indexPath.row].contentId
+            }
         }
+        
+        cell.LikeButtonAction = {
+            if cell.isLiked == true {
+                cell.likeNumLabel.text = String((Int(cell.likeNumLabel.text ?? "") ?? 0) - 1)
+            } else {
+                cell.likeNumLabel.text = String((Int(cell.likeNumLabel.text ?? "") ?? 0) + 1)
+            }
+            cell.isLiked.toggle()
+            cell.likeButton.setImage(cell.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
+            self.postLikeButtonAPI(isClicked: cell.isLiked, contentId: self.contentData[indexPath.row].contentId)
+        }
+        
+        cell.ProfileButtonAction = {
+            let memberId = self.contentData[indexPath.row].memberId
+
+            if memberId == loadUserData()?.memberId ?? 0  {
+                self.tabBarController?.selectedIndex = 3
+                if let selectedViewController = self.tabBarController?.selectedViewController {
+                    self.applyTabBarAttributes(to: selectedViewController.tabBarItem, isSelected: true)
+                }
+                let myViewController = self.tabBarController?.viewControllers ?? [UIViewController()]
+                for (index, controller) in myViewController.enumerated() {
+                    if let tabBarItem = controller.tabBarItem {
+                        if index != self.tabBarController?.selectedIndex {
+                            self.applyTabBarAttributes(to: tabBarItem, isSelected: false)
+                        }
+                    }
+                }
+            } else {
+                let viewController = MyPageViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
+                viewController.memberId = memberId
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }
+        }
+        
+        cell.TransparentButtonAction = {
+            self.alarmTriggerType = cell.alarmTriggerType
+            self.targetMemberId = cell.targetMemberId
+            self.alarmTriggerdId = cell.alarmTriggerdId
+        }
+        
         cell.nicknameLabel.text = contentData[indexPath.row].memberNickname
         cell.transparentLabel.text = "투명도 \(contentData[indexPath.row].memberGhost)%"
         cell.timeLabel.text = "\(contentData[indexPath.row].time.formattedTime())"
@@ -161,12 +274,30 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
         cell.likeNumLabel.text = "\(contentData[indexPath.row].likedNumber)"
         cell.commentNumLabel.text = "\(contentData[indexPath.row].commentNumber)"
         cell.profileImageView.load(url: "\(contentData[indexPath.row].memberProfileUrl)")
+        cell.likeButton.setImage(contentData[indexPath.row].isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
+        cell.isLiked = contentData[indexPath.row].isLiked
+        
+        // 내가 투명도를 누른 유저인 경우 -85% 적용
+        if contentData[indexPath.row].isGhost {
+            cell.grayView.alpha = 0.85
+        } else {
+            let alpha = contentData[indexPath.row].memberGhost
+            cell.grayView.alpha = CGFloat(Double(-alpha) / 100)
+        }
+        
+        self.contentId = contentData[indexPath.row].contentId
+        
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let contentId = contentData[indexPath.row].contentId
         NotificationCenter.default.post(name: MyPageContentViewController.pushViewController, object: nil, userInfo: ["contentId": contentId])
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard let footer = homeCollectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "HomeCollectionFooterView", for: indexPath) as? HomeCollectionFooterView else { return UICollectionReusableView() }
+        return footer
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class MyPageEditProfileViewController: UIViewController, UIGestureRecognizerDelegate {
+final class MyPageEditProfileViewController: UIViewController {
     
     // MARK: - Properties
     
@@ -66,7 +66,12 @@ final class MyPageEditProfileViewController: UIViewController, UIGestureRecogniz
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = false
+        self.navigationController?.navigationBar.backgroundColor = .clear
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
+        self.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isTranslucent = true
         
         let backButton = UIBarButtonItem.backButton(target: self, action: #selector(navBackButtonTapped))
         self.navigationItem.leftBarButtonItem = backButton
@@ -84,9 +89,8 @@ final class MyPageEditProfileViewController: UIViewController, UIGestureRecogniz
 
 extension MyPageEditProfileViewController {
     private func setUI() {
+        self.title = StringLiterals.MyPage.MyPageEditNavigationTitle
         self.view.backgroundColor = .donWhite
-        self.tabBarController?.tabBar.isHidden = true
-        self.tabBarController?.tabBar.isTranslucent = true
         self.title = StringLiterals.MyPage.MyPageEditNavigationTitle
         self.navigationItem.hidesBackButton = true
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -81,6 +81,8 @@ final class MyPageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         
+        self.tabBarController?.tabBar.isHidden = false
+        self.tabBarController?.tabBar.isTranslucent = false
         bindViewModel()
         let image = ImageLiterals.MyPage.icnMenu
         let renderedImage = image.withRenderingMode(.alwaysOriginal)
@@ -120,13 +122,6 @@ final class MyPageViewController: UIViewController {
         let tabBarHeight: CGFloat = 70.0
         
         self.tabBarHeight = tabBarHeight + safeAreaHeight
-        
-        rootView.pageViewController.view.snp.remakeConstraints {
-            $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
-            $0.leading.trailing.equalToSuperview()
-            let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
-            $0.height.equalTo(UIScreen.main.bounds.height - statusBarHeight - navigationBarHeight - self.tabBarHeight)
-        }
     }
 }
 
@@ -135,7 +130,6 @@ final class MyPageViewController: UIViewController {
 extension MyPageViewController {
     private func setUI() {
         self.view.backgroundColor = .donBlack
-        self.tabBarController?.tabBar.isTranslucent = true
         self.navigationController?.navigationBar.backgroundColor = .donBlack
         self.navigationController?.navigationBar.barTintColor = .donBlack
     }
@@ -250,14 +244,14 @@ extension MyPageViewController {
         let vc = MyPageEditProfileViewController(viewModel: MyPageProfileViewModel(networkProvider: NetworkService()))
         vc.nickname = self.rootView.myPageProfileView.userNickname.text ?? ""
         vc.introText = self.rootView.myPageProfileView.userIntroduction.text ?? ""
-        self.navigationController?.pushViewController(vc, animated: true)
+        self.navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc
     private func accountInfoButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
         let vc = MyPageAccountInfoViewController(viewModel: self.viewModel)
-        self.navigationController?.pushViewController(vc, animated: true)
+        self.navigationController?.pushViewController(vc, animated: false)
     }
     
     @objc
@@ -359,6 +353,7 @@ extension MyPageViewController: UICollectionViewDelegate {
                 $0.top.equalTo(rootView.segmentedControl.snp.bottom).offset(2.adjusted)
                 $0.leading.trailing.equalToSuperview()
                 let navigationBarHeight = self.navigationController?.navigationBar.frame.height ?? 0
+                print("\(tabBarHeight)")
                 $0.height.equalTo(UIScreen.main.bounds.height - statusBarHeight - navigationBarHeight - self.tabBarHeight)
             }
         } else if yOffset >= (rootView.myPageProfileView.frame.height - statusBarHeight - navigationBarHeight) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageView.swift
@@ -71,13 +71,16 @@ final class MyPageView: UIView {
         return vc
     }()
     
-    let myPageContentViewController = MyPageContentViewController()
-    let myPageCommentViewController = MyPageCommentViewController()
+    let myPageContentViewController = MyPageContentViewController(viewModel: HomeViewModel(networkProvider: NetworkService()))
+    let myPageCommentViewController = MyPageCommentViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
     
     var myPageBottomsheet = DontBeBottomSheetView(profileEditImage: ImageLiterals.MyPage.btnEditProfile,
                                                   accountInfoImage: ImageLiterals.MyPage.btnAccount,
                                                   feedbackImage: ImageLiterals.MyPage.btnFeedback,
                                                   customerCenterImage: ImageLiterals.MyPage.btnCustomerCenter)
+    
+    var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
+    var warnBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnWarn)
     
     // MARK: - Life Cycles
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -29,7 +29,7 @@ final class PostViewController: UIViewController {
             .map { _ in return self.contentId }
             .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
             .eraseToAnyPublisher()
-    }    
+    }
     let viewModel: PostViewModel
     private var cancelBag = CancelBag()
     
@@ -43,7 +43,7 @@ final class PostViewController: UIViewController {
     // MARK: - UI Components
     
     lazy var postView = PostView()
-
+    
     let grayView: DontBeTransparencyGrayView = {
         let view = DontBeTransparencyGrayView()
         view.alpha = 0
@@ -93,11 +93,11 @@ final class PostViewController: UIViewController {
         super.viewWillAppear(animated)
         
         NotificationCenter.default.addObserver(
-                  self,
-                  selector: #selector(self.didDismissDetailNotification(_:)),
-                  name: NSNotification.Name("DismissReplyView"),
-                  object: nil
-              )
+            self,
+            selector: #selector(self.didDismissDetailNotification(_:)),
+            name: NSNotification.Name("DismissReplyView"),
+            object: nil
+        )
         
         self.navigationItem.hidesBackButton = true
         self.navigationItem.title = StringLiterals.Post.navigationTitleLabel
@@ -180,11 +180,11 @@ extension PostViewController {
     }
     
     @objc func didDismissDetailNotification(_ notification: Notification) {
-         DispatchQueue.main.async {
-             self.getAPI()
-             self.postReplyCollectionView.reloadData()
-         }
-     }
+        DispatchQueue.main.async {
+            self.getAPI()
+            self.postReplyCollectionView.reloadData()
+        }
+    }
     private func setRefreshControll() {
         refreshControl.addTarget(self, action: #selector(refreshPost), for: .valueChanged)
         postReplyCollectionView.refreshControl = refreshControl
@@ -404,9 +404,9 @@ extension PostViewController {
                     self.postView.likeNumLabel.text = String((Int(self.postView.likeNumLabel.text ?? "") ?? 0) - 1)
                     self.postView.likeButton.setImage(ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
                 }
-             }
-             .store(in: self.cancelBag)
-
+            }
+            .store(in: self.cancelBag)
+        
         output.getPostReplyData
             .receive(on: RunLoop.main)
             .sink { data in
@@ -450,11 +450,11 @@ extension PostViewController {
             .map { _ in return (!isClicked, commentId, commentText) }
             .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
             .eraseToAnyPublisher()
-
+        
         let input = PostViewModel.Input(viewUpdate: nil, likeButtonTapped: nil, collectionViewUpdata: nil, commentLikeButtonTapped: commentLikedButtonTapped)
-
+        
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
-
+        
         output.toggleLikeButton
             .sink { _ in }
             .store(in: self.cancelBag)
@@ -525,7 +525,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
         cell.profileImageView.load(url: "\(viewModel.postReplyData[indexPath.row].memberProfileUrl)")
         self.commentId = viewModel.postReplyData[indexPath.row].commentId
         cell.likeButton.setImage(viewModel.postReplyData[indexPath.row].isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
-        cell.isLiked = self.viewModel.postReplyData[indexPath.row].isLiked        
+        cell.isLiked = self.viewModel.postReplyData[indexPath.row].isLiked
         // 내가 투명도를 누른 유저인 경우 -85% 적용
         if self.viewModel.postReplyData[indexPath.row].isGhost {
             cell.grayView.alpha = 0.85

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -479,6 +479,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
         cell.alarmTriggerType = "commentGhost"
         cell.targetMemberId = viewModel.postReplyData[indexPath.row].memberId
         cell.alarmTriggerdId = self.contentId
+        
         if viewModel.postReplyData[indexPath.row].memberId == loadUserData()?.memberId {
             cell.ghostButton.isHidden = true
             cell.verticalTextBarView.isHidden = true

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
@@ -28,11 +28,11 @@ final class PostReplyTextFieldView: UIView {
         return view
     }()
     
-    private let profileImageView: UIImageView = {
+    let profileImageView: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
-        image.image = ImageLiterals.Onboarding.imgTwo
+        image.image = ImageLiterals.Common.imgProfile
         image.backgroundColor = .lightGray
         image.layer.cornerRadius = 20.adjusted
         return image


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 마이페이지 게시글, 답글에 좋아요 액션, 게시물 삭제 액션 추가했습니다~!

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/913e4ca7-5471-446a-ab0d-01daed66118a" width ="250">|

## 📟 관련 이슈
- Resolved: #109 
