### PR TITLE
[Fix] #115 - 답글 작성 및 삭제 데이터 변경

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/DeleteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/DeleteReplyViewController.swift
@@ -9,34 +9,34 @@ import Combine
 import UIKit
 
 final class DeleteReplyViewController: UIViewController {
-    
+
     // MARK: - Properties
     var commentId: Int = 0
     var viewModel: DeleteReplyViewModel
     private var cancelBag = CancelBag()
-    
+
     // MARK: - UI Components
-    
+
     private let deleteReplyPopupView = DontBePopupView(popupTitle: "답글 삭제",
                                                       popupContent: StringLiterals.Home.deletePopupContentLabel,
                                                       leftButtonTitle: StringLiterals.Home.deletePopupLefteftButtonTitle,
                                                       rightButtonTitle: StringLiterals.Home.deletePopupRightButtonTitle)
-    
+
     private lazy var deleteButtonTapped = deleteReplyPopupView.confirmButton.publisher(for: .touchUpInside).map { _ in
         return self.commentId
     }.eraseToAnyPublisher()
-    
+
     private let myView = PostPopupView()
     private lazy var postVC = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
-    
+
     // MARK: - Life Cycles
-    
+
     override func loadView() {
         super.loadView()
-        
+
         view = myView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -45,24 +45,24 @@ final class DeleteReplyViewController: UIViewController {
         setLayout()
         setDelegate()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         getAPI()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
+
         NotificationCenter.default.post(name: NSNotification.Name("DismissDetailView"), object: nil, userInfo: nil)
-        
+
         NotificationCenter.default.post(name: NSNotification.Name("DismissReplyView"), object: nil, userInfo: nil)
     }
-    
+
     init(viewModel: DeleteReplyViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -72,23 +72,23 @@ final class DeleteReplyViewController: UIViewController {
 
 extension DeleteReplyViewController {
     private func setUI() {
-        
+
     }
-    
+
     private func setHierarchy() {
         view.addSubviews(deleteReplyPopupView)
     }
-    
+
     private func setLayout() {
         deleteReplyPopupView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
-    
+
     private func setDelegate() {
         deleteReplyPopupView.delegate = self
     }
-    
+
     @objc
     private func dismissViewController() {
         self.dismiss(animated: false)
@@ -100,9 +100,9 @@ extension DeleteReplyViewController {
 extension DeleteReplyViewController {
     private func getAPI() {
         let input = DeleteReplyViewModel.Input(deleteButtonDidTapped: deleteButtonTapped)
-        
+
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
-        
+
         output.popView
             .receive(on: RunLoop.main)
             .sink { _ in
@@ -118,10 +118,9 @@ extension DeleteReplyViewController: DontBePopupDelegate {
     func cancleButtonTapped() {
         self.dismiss(animated: false)
     }
-    
+
     func confirmButtonTapped() {
         self.postVC.postReplyCollectionView.reloadData()
     }
 }
-
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -467,6 +467,7 @@ extension PostViewController {
     
     private func bindPostData(data: PostDetailResponseDTO) {
         self.collectionHeaderView.profileImageView.load(url: data.memberProfileUrl)
+        self.textFieldView.replyTextFieldLabel.text = "\(data.memberNickname)" + StringLiterals.Post.textFieldLabel
         self.postView
             .postNicknameLabel.text = data.memberNickname
         self.postUserNickname = "\(data.memberNickname)"

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -22,6 +22,7 @@ final class PostViewController: UIViewController {
     var warnBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnWarn)
     var transparentPopupVC = TransparentPopupViewController()
     var deletePostPopupVC = DeletePopupViewController(viewModel: DeletePostViewModel(networkProvider: NetworkService()))
+    var deleteReplyPopupVC = DeleteReplyViewController(viewModel: DeleteReplyViewModel(networkProvider: NetworkService()))
     lazy var collectionHeaderView = PostCollectionViewHeader()
     let warnUserURL = NSURL(string: "\(StringLiterals.Network.warnUserGoogleFormURL)")
     private var likeButtonTapped: AnyPublisher<Int, Never> {
@@ -54,7 +55,7 @@ final class PostViewController: UIViewController {
     }()
     
     private lazy var textFieldView = PostReplyTextFieldView()
-    lazy var postReplyCollectionView = PostReplyCollectionView().collectionView
+    var postReplyCollectionView = PostReplyCollectionView().collectionView
     private lazy var greenTextField = textFieldView.greenTextFieldView
     private var uploadToastView: DontBeToastView?
     private var alreadyTransparencyToastView: DontBeToastView?
@@ -138,6 +139,7 @@ extension PostViewController {
         textFieldView.replyTextFieldLabel.text = (postUserNickname ?? "") + StringLiterals.Post.textFieldLabel
         transparentPopupVC.modalPresentationStyle = .overFullScreen
         deletePostPopupVC.modalPresentationStyle = .overFullScreen
+        deleteReplyPopupVC.modalPresentationStyle = .overFullScreen
     }
     
     private func setHierarchy() {
@@ -308,7 +310,14 @@ extension PostViewController {
     @objc
     func deletePost() {
         popView()
-        presentView()
+        deleteReplyPopupView()
+    }
+    
+    @objc
+    func deleteReplyPost() {
+        print("답글 삭제")
+        popView()
+        deleteReplyPopupView()
     }
     
     @objc
@@ -354,6 +363,11 @@ extension PostViewController {
         deletePostPopupVC.contentId = self.contentId
         
         self.present(self.deletePostPopupVC, animated: false, completion: nil)
+    }
+    
+    func deleteReplyPopupView() {
+        deleteReplyPopupVC.commentId = self.commentId
+        self.present(self.deleteReplyPopupVC, animated: false, completion: nil)
     }
     
     @objc
@@ -447,8 +461,7 @@ extension PostViewController {
     
     private func bindPostData(data: PostDetailResponseDTO) {
         self.collectionHeaderView.profileImageView.load(url: data.memberProfileUrl)
-        print("0\(data.memberNickname)")
-        
+
         self.postView
             .postNicknameLabel.text = data.memberNickname
         
@@ -519,6 +532,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             self.deleteBottomsheet.warnButton.removeFromSuperview()
             
             cell.KebabButtonAction = {
+                print("나야")
                 self.deleteBottomsheet.showSettings()
                 self.deleteBottomsheet.deleteButton.addTarget(self, action: #selector(self.deletePost), for: .touchUpInside)
                 self.commentId = self.viewModel.postReplyData[indexPath.row].commentId
@@ -529,6 +543,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             self.warnBottomsheet.deleteButton.removeFromSuperview()
             
             cell.KebabButtonAction = {
+                print("너야")
                 self.warnBottomsheet.showSettings()
                 self.warnBottomsheet.warnButton.addTarget(self, action: #selector(self.warnUser), for: .touchUpInside)
                 self.commentId = self.viewModel.postReplyData[indexPath.row].commentId

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -23,10 +23,12 @@ final class WriteReplyViewController: UIViewController {
     
     var contentId: Int = 0
     var tabBarHeight: CGFloat = 0
+    var userNickname: String = ""
+    var userContent: String = ""
     
     // MARK: - UI Components
     
-    private let writeView = WriteReplyView()
+    let writeView = WriteReplyView()
     private lazy var cancelReplyPopupVC = CancelReplyPopupViewController()
     
     // MARK: - Life Cycles
@@ -48,7 +50,6 @@ final class WriteReplyViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         getAPI()
         setUI()
         setHierarchy()
@@ -56,6 +57,9 @@ final class WriteReplyViewController: UIViewController {
         setDelegate()
         setBottomSheet()
         setNavigationBarButtonItem()
+        
+        writeView.writeReplyPostview.postNicknameLabel.text = self.userNickname
+        writeView.writeReplyPostview.contentTextLabel.text = self.userContent
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -134,9 +138,12 @@ extension WriteReplyViewController {
     }
     
     private func setNavigationBarButtonItem() {
-        let cancelButton = UIBarButtonItem(title: "취소", primaryAction: .init(handler: { _Arg in
-            self.present(self.cancelReplyPopupVC, animated: false, completion: nil)
-        }))
+        let cancelButton = UIBarButtonItem(
+            title: StringLiterals.Write.writeNavigationBarButtonItemTitle,
+            style: .plain,
+            target: self,
+            action: #selector(cancleNavigationBarButtonTapped)
+        )
         navigationItem.leftBarButtonItem = cancelButton
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.donGray11,
@@ -148,6 +155,16 @@ extension WriteReplyViewController {
     
     public func dismissView() {
         self.dismiss(animated: true)
+    }
+    
+    @objc
+    private func cancleNavigationBarButtonTapped() {
+        // 텍스트가 비어있는 경우 POP
+        if self.writeView.writeReplyView.contentTextView.text == "" {
+            popupNavigation()
+        } else {
+            self.present(self.cancelReplyPopupVC, animated: false, completion: nil)
+        }
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
@@ -32,9 +32,9 @@ final class WriteReplyEditorView: UIView {
         return imageView
     }()
     
-    private let userNickname: UILabel = {
+    var userNickname: UILabel = {
         let label = UILabel()
-        label.text = "뚜비요"
+        label.text = "\(loadUserData()?.userNickname ?? "")"
         label.font = UIFont.font(.body1)
         label.textColor = .donBlack
         return label
@@ -173,7 +173,7 @@ extension WriteReplyEditorView {
         keyboardToolbarView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56.adjusted)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
         }
         
         circleProgressBar.snp.makeConstraints {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
@@ -30,7 +30,7 @@ final class WriteReplyPostView: UIView {
         return image
     }()
     
-    public let postNicknameLabel: UILabel = {
+    var postNicknameLabel: UILabel = {
         let label = UILabel()
         label.textColor = .donBlack
         label.text = "Don't be야 사랑해~"

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 final class WriteReplyView: UIView {
-
+    
     // MARK: - Properties
     
     // MARK: - UI Components
@@ -57,7 +57,7 @@ extension WriteReplyView {
         writeReplyView.snp.makeConstraints {
             $0.top.equalTo(writeReplyPostview.contentTextLabel.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.bottom.equalToSuperview()
         }
     }
     


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 답글 삭제 ViewModel 연결 부분 수정했습니다.
- 답글 작성 뷰 키보드 영역 수정했습니다.
- 답글 작성 뷰에 있는 데이터 불러왔습니다.
- 답글 작성 뷰 텍스트 필드에 닉네임 추가했습니다.
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/640ade84-91dd-4f18-a6ef-d2611a04b453" width ="250">|

## 📟 관련 이슈
- Resolved: #115 
