### PR TITLE
Fix [#122]  UI 디테일 수정

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Application/AppDelegate.swift
+++ b/DontBe-iOS/DontBe-iOS/Application/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UINavigationBar.appearance().titleTextAttributes = [
             NSAttributedString.Key.font: UIFont.font(.body1),
             NSAttributedString.Key.foregroundColor: UIColor.donBlack
-        ] 
+        ]
         
         KakaoSDK.initSDK(appKey: Config.nativeAppKey)
         return true

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -397,6 +397,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         cell.profileImageView.load(url: "\(viewModel.postData[indexPath.row].memberProfileUrl)")
         cell.likeButton.setImage(viewModel.postData[indexPath.row].isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
         cell.isLiked = self.viewModel.postData[indexPath.row].isLiked
+        cell.likeButton.setImage(cell.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
         
         // 내가 투명도를 누른 유저인 경우 -85% 적용
         if self.viewModel.postData[indexPath.row].isGhost {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -376,7 +376,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
             } else {
                 let viewController = MyPageViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
                 viewController.memberId = memberId
-                self.navigationController?.pushViewController(viewController, animated: true)
+                self.navigationController?.pushViewController(viewController, animated: false)
             }
         }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -95,6 +95,8 @@ final class MyPageAccountInfoViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isTranslucent = true
         self.navigationItem.hidesBackButton = true
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .clear

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -66,6 +66,8 @@ final class MyPageEditProfileViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isTranslucent = true
         self.navigationItem.hidesBackButton = true
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .clear

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -131,6 +131,7 @@ final class MyPageViewController: UIViewController {
         }
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donWhite]
         self.navigationItem.hidesBackButton = true
+        self.navigationController?.navigationBar.isHidden = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewControllers/NotificationViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/ViewControllers/NotificationViewController.swift
@@ -164,7 +164,7 @@ extension NotificationViewController: UITableViewDelegate {
                     }
                 } else if selectedNotification?.notificationType == .actingContinue {
                     let viewController = WriteViewController(viewModel: WriteViewModel(networkProvider: NetworkService()))
-                    self.navigationController?.pushViewController(viewController, animated: true)
+                    self.navigationController?.pushViewController(viewController, animated: false)
                 } else {
                     let viewController = PostViewController(viewModel: PostViewModel(networkProvider: NetworkService()))
                     viewController.contentId = selectedNotification?.notificationTriggerId ?? 0

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -366,7 +366,7 @@ extension PostViewController {
         } else {
             let viewController = MyPageViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
             viewController.memberId = memberId
-            self.navigationController?.pushViewController(viewController, animated: true)
+            self.navigationController?.pushViewController(viewController, animated: false)
         }
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -631,8 +631,6 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             header.likeNumLabel.text = self.postView.likeNumLabel.text
             header.commentNumLabel.text = self.postView.commentNumLabel.text
             header.isLiked = self.postView.isLiked
-            print(header.isLiked)
-            print("DSFAFSDFA")
             header.likeButton.setImage(header.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
             header.ghostButton.addTarget(self, action: #selector(transparentShowPopupButton), for: .touchUpInside)
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -194,6 +194,8 @@ extension PostViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(dismissViewController), name: CancelReplyPopupViewController.popViewController, object: nil)
         
         NotificationCenter.default.addObserver(self, selector: #selector( self.likeButtonAction), name: NSNotification.Name("likeButtonTapped"), object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector( self.profileButtonAction), name: NSNotification.Name("profileButtonTapped"), object: nil)
     }
     
     @objc func didDismissDetailNotification(_ notification: Notification) {
@@ -320,6 +322,11 @@ extension PostViewController {
             .sink { _ in }
             .store(in: self.cancelBag)
 
+    }
+    
+    @objc
+    func profileButtonAction() {
+        self.pushToMypage()
     }
     
     private func addDeleteButtonAction() {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewModel/PostViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewModel/PostViewModel.swift
@@ -65,14 +65,12 @@ final class PostViewModel: ViewModelType {
                         if value.0 {
                             let statusCode = try await self.deleteLikeButtonAPI(contentId: value.1)?.status
                             if statusCode == 200 {
-                                self.isLikeButtonClicked.toggle()
-                                self.toggleLikeButton.send(self.isLikeButtonClicked)
+                                self.toggleLikeButton.send(!value.0)
                             }
                         } else {
                             let statusCode = try await self.postLikeButtonAPI(contentId: value.1)?.status
                             if statusCode == 201 {
-                                self.isLikeButtonClicked.toggle()
-                                self.toggleLikeButton.send(self.isLikeButtonClicked)
+                                self.toggleLikeButton.send(value.0)
                             }
                         }
                     } catch {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostCollectionViewHeader.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostCollectionViewHeader.swift
@@ -46,6 +46,7 @@ final class PostCollectionViewHeader: UICollectionReusableView {
         image.clipsToBounds = true
         image.layer.cornerRadius = 22.adjusted
         image.image = ImageLiterals.Common.imgProfile
+        image.isUserInteractionEnabled = true
         return image
     }()
     
@@ -288,6 +289,7 @@ extension PostCollectionViewHeader {
     
     func setAddTarget() {
         likeButton.addTarget(self, action: #selector(likeToggleButton), for: .touchUpInside)
+        profileImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(profileImageCliked)))
     }
     
     @objc
@@ -300,5 +302,10 @@ extension PostCollectionViewHeader {
         isLiked.toggle()
         likeButton.setImage(isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
         NotificationCenter.default.post(name: NSNotification.Name("likeButtonTapped"), object: nil, userInfo: nil)
+    }
+    
+    @objc
+    func profileImageCliked() {
+        NotificationCenter.default.post(name: NSNotification.Name("profileButtonTapped"), object: nil, userInfo: nil)
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
@@ -115,8 +115,7 @@ extension WriteViewController {
         output.popViewController
             .sink { _ in
                 DispatchQueue.main.async {
-                    self.navigationController?.popViewController(animated: true)
-                    self.tabBarController?.selectedIndex = 0
+                    self.popupNavigation()
                     self.sendData()
                 }
             }
@@ -128,12 +127,19 @@ extension WriteViewController {
     }
     
     private func popupNavigation() {
-        self.navigationController?.popViewController(animated: true)
         self.tabBarController?.selectedIndex = 0
-        
         if let selectedViewController = self.tabBarController?.selectedViewController {
             self.applyTabBarAttributes(to: selectedViewController.tabBarItem, isSelected: true)
         }
+        let myViewController = self.tabBarController?.viewControllers ?? [UIViewController()]
+        for (index, controller) in myViewController.enumerated() {
+            if let tabBarItem = controller.tabBarItem {
+                if index != self.tabBarController?.selectedIndex {
+                    self.applyTabBarAttributes(to: tabBarItem, isSelected: false)
+                }
+            }
+        }
+        self.navigationController?.popViewController(animated: false)
     }
     
     @objc


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 헤더뷰 프로필 눌리게 수정
- 탭바 검은 영역 수정
- 헤더뷰 좋아요 버튼 누르면 실시간 반영
- 알림뷰 -> 글쓰기뷰 UI 오류 해결

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 탭바 검은 영역은 push할 때 animated false로 설정해주시면 됩니다 !
## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|헤더뷰 프로필 눌리게 <br> 수정 및  push될 때 <br> 탭바 검은 영역 수정|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/4b3e2d97-37fc-48e6-98e1-91f4ab26f136" width ="230">|헤더뷰 좋아요 버튼 <br>실시간 반영|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/6bddf9d6-25b7-41df-853f-59420a9cb46b" width ="230">|

알림뷰 -> 글쓰기뷰 UI 오류 해결

https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/917fb5a1-eb0f-48bf-8155-ac8cb2030dea

## 📟 관련 이슈
- Resolved: #122 
