### PR TITLE
Feat [#123] 답글 케밥 버튼 기능 구현

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -227,11 +227,11 @@ extension HomeViewController {
                         self.uploadToastView?.container.backgroundColor = .donPrimary
                     }
                     
-                    UIView.animate(withDuration: 1.0, delay: 3, options: .curveEaseIn) {
+                    UIView.animate(withDuration: 1.0, delay: 2, options: .curveEaseIn) {
                         self.uploadToastView?.alpha = 0
                     }
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                         self.uploadToastView?.circleProgressBar.alpha = 1
                         self.uploadToastView?.checkImageView.alpha = 0
                         self.uploadToastView?.toastLabel.text = StringLiterals.Toast.uploading

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -283,6 +283,7 @@ extension MyPageCommentViewController: UICollectionViewDataSource, UICollectionV
             self.alarmTriggerType = cell.alarmTriggerType
             self.targetMemberId = cell.targetMemberId
             self.alarmTriggerdId = cell.alarmTriggerdId
+            NotificationCenter.default.post(name: MyPageContentViewController.ghostButtonTapped, object: nil)
         }
         
         cell.nicknameLabel.text = commentData[indexPath.row].memberNickname

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -140,16 +140,17 @@ extension MyPageCommentViewController {
     
     @objc
     private func deleteButtonTapped() {
-        popView()
+        popDeleteView()
         deleteReplyPopupView()
     }
     
     @objc
     private func warnButtonTapped() {
+        popWarnView()
         NotificationCenter.default.post(name: MyPageContentViewController.warnUserButtonTapped, object: nil)
     }
     
-    func popView() {
+    func popDeleteView() {
         if UIApplication.shared.keyWindowInConnectedScenes != nil {
             UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
                 self.deleteBottomsheet.dimView.alpha = 0
@@ -159,6 +160,20 @@ extension MyPageCommentViewController {
             })
             deleteBottomsheet.dimView.removeFromSuperview()
             deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+        refreshPost()
+    }
+    
+    func popWarnView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.warnBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.warnBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteBottomsheet.frame.width, height: self.warnBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            warnBottomsheet.dimView.removeFromSuperview()
+            warnBottomsheet.bottomsheetView.removeFromSuperview()
         }
         refreshPost()
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -56,6 +56,7 @@ final class MyPageContentViewController: UIViewController {
         button.layer.cornerRadius = 4.adjusted
         button.layer.borderWidth = 1.adjusted
         button.layer.borderColor = UIColor.donSecondary.cgColor
+        button.isHidden = true
         return button
     }()
     
@@ -80,13 +81,13 @@ final class MyPageContentViewController: UIViewController {
         setHierarchy()
         setLayout()
         setDelegate()
-        setNotification()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         
         setRefreshControll()
+        setNotification()
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -158,16 +158,17 @@ extension MyPageContentViewController {
     
     @objc
     private func deleteButtonTapped() {
-        popView()
+        popDeleteView()
         presentView()
     }
     
     @objc
     private func warnButtonTapped() {
+        popWarnView()
         NotificationCenter.default.post(name: MyPageContentViewController.warnUserButtonTapped, object: nil)
     }
     
-    func popView() {
+    func popDeleteView() {
         if UIApplication.shared.keyWindowInConnectedScenes != nil {
             UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
                 self.deleteBottomsheet.dimView.alpha = 0
@@ -177,6 +178,20 @@ extension MyPageContentViewController {
             })
             deleteBottomsheet.dimView.removeFromSuperview()
             deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+        refreshPost()
+    }
+    
+    func popWarnView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.warnBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.warnBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteBottomsheet.frame.width, height: self.warnBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            warnBottomsheet.dimView.removeFromSuperview()
+            warnBottomsheet.bottomsheetView.removeFromSuperview()
         }
         refreshPost()
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -18,6 +18,7 @@ final class MyPageContentViewController: UIViewController {
     static let pushViewController = NSNotification.Name("pushViewController")
     static let reloadData = NSNotification.Name("reloadData")
     static let warnUserButtonTapped = NSNotification.Name("warnUserButtonTapped")
+    static let ghostButtonTapped = NSNotification.Name("ghostButtonTapped")
     
     var showUploadToastView: Bool = false
     var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
@@ -296,6 +297,7 @@ extension MyPageContentViewController: UICollectionViewDataSource, UICollectionV
             self.alarmTriggerType = cell.alarmTriggerType
             self.targetMemberId = cell.targetMemberId
             self.alarmTriggerdId = cell.alarmTriggerdId
+            NotificationCenter.default.post(name: MyPageContentViewController.ghostButtonTapped, object: nil)
         }
         
         cell.nicknameLabel.text = contentData[indexPath.row].memberNickname

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -188,6 +188,7 @@ extension MyPageViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(pushViewController), name: MyPageContentViewController.pushViewController, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadData), name: MyPageContentViewController.reloadData, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(warnButtonTapped), name: MyPageContentViewController.warnUserButtonTapped, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ghostButtonTapped), name: MyPageContentViewController.ghostButtonTapped, object: nil)
     }
     
     private func setAddTarget() {
@@ -389,12 +390,7 @@ extension MyPageViewController {
     }
     
     @objc
-    private func deleteButtonTapped() {
-        print("deleteButtonTapped")
-    }
-    
-    @objc
-    private func transparencyButtonTapped(_ notification: Notification) {
+    private func ghostButtonTapped() {
         self.present(self.transparentPopupVC, animated: false, completion: nil)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -187,7 +187,7 @@ extension MyPageViewController {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(pushViewController), name: MyPageContentViewController.pushViewController, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadData), name: MyPageContentViewController.reloadData, object: nil)
-//        NotificationCenter.default.addObserver(self, selector: #selector(warnUserButtonTapped), name: MyPageContentViewController.reloadData, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(warnButtonTapped), name: MyPageContentViewController.warnUserButtonTapped, object: nil)
     }
     
     private func setAddTarget() {
@@ -271,6 +271,7 @@ extension MyPageViewController {
                     self.rootView.myPageContentViewController.firstContentButton.isHidden = true
                 } else {
                     self.rootView.myPageContentViewController.noContentLabel.isHidden = false
+                    self.rootView.myPageContentViewController.firstContentButton.isHidden = false
                 }
                 self.rootView.myPageContentViewController.homeCollectionView.reloadData()
             }
@@ -298,11 +299,9 @@ extension MyPageViewController {
         
         if data.memberId != loadUserData()?.memberId ?? 0 {
             self.rootView.myPageContentViewController.noContentLabel.text = "아직 \(data.nickname)" + StringLiterals.MyPage.myPageNoContentOtherLabel
-            self.rootView.myPageContentViewController.firstContentButton.isHidden = true
             self.rootView.myPageCommentViewController.noCommentLabel.text = "아직 \(data.nickname)" + StringLiterals.MyPage.myPageNoCommentOtherLabel
         } else {
             self.rootView.myPageContentViewController.noContentLabel.text = "\(data.nickname)" + StringLiterals.MyPage.myPageNoContentLabel
-            self.rootView.myPageContentViewController.firstContentButton.isHidden = false
             self.rootView.myPageCommentViewController.noCommentLabel.text = StringLiterals.MyPage.myPageNoCommentLabel
         }
     }
@@ -381,7 +380,6 @@ extension MyPageViewController {
     
     @objc
     private func warnButtonTapped() {
-        print("ddd")
         rootView.warnBottomsheet.handleDismiss()
         let warnView: SFSafariViewController
         if let warnURL = self.warnUserURL {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -241,11 +241,11 @@ extension PostViewController {
                     self.uploadToastView?.container.backgroundColor = .donPrimary
                 }
                 
-                UIView.animate(withDuration: 1.0, delay: 3, options: .curveEaseIn) {
+                UIView.animate(withDuration: 1.0, delay: 2, options: .curveEaseIn) {
                     self.uploadToastView?.alpha = 0
                 }
                 
-                DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                     self.uploadToastView?.circleProgressBar.alpha = 1
                     self.uploadToastView?.checkImageView.alpha = 0
                     self.uploadToastView?.toastLabel.text = StringLiterals.Toast.uploading
@@ -272,11 +272,11 @@ extension PostViewController {
                 $0.height.equalTo(44.adjusted)
             }
             
-            UIView.animate(withDuration: 1.5, delay: 1, options: .curveEaseIn) {
+            UIView.animate(withDuration: 1.0, delay: 1, options: .curveEaseIn) {
                 self.alreadyTransparencyToastView?.alpha = 0
             }
             
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                 self.alreadyTransparencyToastView?.removeFromSuperview()
             }
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -18,11 +18,16 @@ final class PostViewController: UIViewController {
     private lazy var postDividerView = postView.horizontalDivierView
     private lazy var ghostButton = postView.ghostButton
     let refreshControl = UIRefreshControl()
-    var deleteBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
+    
+    var deletePostBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
+    var deleteReplyBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnDelete)
+    
     var warnBottomsheet = DontBeBottomSheetView(singleButtonImage: ImageLiterals.Posting.btnWarn)
+    
     var transparentPopupVC = TransparentPopupViewController()
     var deletePostPopupVC = DeletePopupViewController(viewModel: DeletePostViewModel(networkProvider: NetworkService()))
     var deleteReplyPopupVC = DeleteReplyViewController(viewModel: DeleteReplyViewModel(networkProvider: NetworkService()))
+    
     var writeReplyVC = WriteReplyViewController(viewModel: WriteReplyViewModel(networkProvider: NetworkService()))
     var writeReplyView = WriteReplyView()
     
@@ -194,6 +199,7 @@ extension PostViewController {
             self.postReplyCollectionView.reloadData()
         }
     }
+    
     private func setRefreshControll() {
         refreshControl.addTarget(self, action: #selector(refreshPost), for: .valueChanged)
         postReplyCollectionView.refreshControl = refreshControl
@@ -289,8 +295,8 @@ extension PostViewController {
     @objc
     func deleteOrWarn() {
         if self.memberId == loadUserData()?.memberId ?? 0 {
-            self.deleteBottomsheet.showSettings()
-            addDeleteButtonAction()
+            self.deleteReplyBottomsheet.showSettings()
+            addDeleteReplyButtonAction()
         } else {
             self.warnBottomsheet.showSettings()
             addWarnUserButtonAction()
@@ -320,9 +326,25 @@ extension PostViewController {
         self.pushToMypage()
     }
     
-    private func addDeleteButtonAction() {
-        self.deleteBottomsheet.warnButton.removeFromSuperview()
-        self.deleteBottomsheet.deleteButton.addTarget(self, action: #selector(deletePost), for: .touchUpInside)
+    @objc
+    func headerKebabButtonAction() {
+        if self.memberId == loadUserData()?.memberId ?? 0 {
+            self.deletePostBottomsheet.showSettings()
+            addDeletePostButtonAction()
+        } else {
+            self.warnBottomsheet.showSettings()
+            addWarnUserButtonAction()
+        }
+    }
+    
+    private func addDeletePostButtonAction() {
+        self.deletePostBottomsheet.warnButton.removeFromSuperview()
+        self.deletePostBottomsheet.deleteButton.addTarget(self, action: #selector(deletePost), for: .touchUpInside)
+    }
+    
+    private func addDeleteReplyButtonAction() {
+        self.deleteReplyBottomsheet.warnButton.removeFromSuperview()
+        self.deleteReplyBottomsheet.deleteButton.addTarget(self, action: #selector(deleteReply), for: .touchUpInside)
     }
     
     private func addWarnUserButtonAction() {
@@ -332,15 +354,21 @@ extension PostViewController {
     
     @objc
     func deletePost() {
-        popView()
+        popPostView()
+        deletePostPopupView()
+    }
+    
+    @objc
+    func deleteReply() {
+        popReplyView()
         deleteReplyPopupView()
     }
     
     @objc
-    func deleteReplyPost() {
-        print("답글 삭제")
-        popView()
-        deleteReplyPopupView()
+    private func warnUser() {
+        popWarnView()
+        let safariView: SFSafariViewController = SFSafariViewController(url: self.warnUserURL! as URL)
+        self.present(safariView, animated: true, completion: nil)
     }
     
     @objc
@@ -365,26 +393,65 @@ extension PostViewController {
         }
     }
     
-    func popView() {
+    func popPostView() {
         if UIApplication.shared.keyWindowInConnectedScenes != nil {
             UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
-                self.deleteBottomsheet.dimView.alpha = 0
+                self.deletePostBottomsheet.dimView.alpha = 0
                 self.postView.deleteBottomsheet.dimView.alpha = 0
                 if let window = UIApplication.shared.keyWindowInConnectedScenes {
-                    self.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteBottomsheet.frame.width, height: self.deleteBottomsheet.bottomsheetView.frame.height)
+                    self.deletePostBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteReplyBottomsheet.frame.width, height: self.deletePostBottomsheet.bottomsheetView.frame.height)
                     self.postView.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.postView.deleteBottomsheet.frame.width, height: self.postView.deleteBottomsheet.bottomsheetView.frame.height)
                 }
             })
-            deleteBottomsheet.dimView.removeFromSuperview()
-            deleteBottomsheet.bottomsheetView.removeFromSuperview()
+            deletePostBottomsheet.dimView.removeFromSuperview()
+            deletePostBottomsheet.bottomsheetView.removeFromSuperview()
             postView.deleteBottomsheet.dimView.removeFromSuperview()
             postView.deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+    }
+    
+    func popReplyView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.deleteReplyBottomsheet.dimView.alpha = 0
+                self.postView.deleteBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.deleteReplyBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteReplyBottomsheet.frame.width, height: self.deleteReplyBottomsheet.bottomsheetView.frame.height)
+                    self.postView.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.postView.deleteBottomsheet.frame.width, height: self.postView.deleteBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            deleteReplyBottomsheet.dimView.removeFromSuperview()
+            deleteReplyBottomsheet.bottomsheetView.removeFromSuperview()
+            postView.deleteBottomsheet.dimView.removeFromSuperview()
+            postView.deleteBottomsheet.bottomsheetView.removeFromSuperview()
+        }
+    }
+    
+    func popWarnView() {
+        if UIApplication.shared.keyWindowInConnectedScenes != nil {
+            UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.deleteReplyBottomsheet.dimView.alpha = 0
+                self.postView.deleteBottomsheet.dimView.alpha = 0
+                if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                    self.deleteReplyBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.deleteReplyBottomsheet.frame.width, height: self.deleteReplyBottomsheet.bottomsheetView.frame.height)
+                    self.postView.deleteBottomsheet.bottomsheetView.frame = CGRect(x: 0, y: window.frame.height, width: self.postView.deleteBottomsheet.frame.width, height: self.postView.deleteBottomsheet.bottomsheetView.frame.height)
+                }
+            })
+            warnBottomsheet.dimView.removeFromSuperview()
+            warnBottomsheet.bottomsheetView.removeFromSuperview()
+            postView.warnBottomsheet.dimView.removeFromSuperview()
+            postView.warnBottomsheet.bottomsheetView.removeFromSuperview()
         }
     }
     
     func presentView() {
         deletePostPopupVC.contentId = self.contentId
         
+        self.present(self.deletePostPopupVC, animated: false, completion: nil)
+    }
+    
+    func deletePostPopupView() {
+        deletePostPopupVC.contentId = self.contentId
         self.present(self.deletePostPopupVC, animated: false, completion: nil)
     }
     
@@ -438,11 +505,6 @@ extension PostViewController {
     @objc
     private func dismissViewController() {
         self.dismiss(animated: false)
-    }
-    
-    @objc private func warnUser() {
-        let safariView: SFSafariViewController = SFSafariViewController(url: self.warnUserURL! as URL)
-        self.present(safariView, animated: true, completion: nil)
     }
 }
 
@@ -550,12 +612,11 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
         if viewModel.postReplyData[indexPath.row].memberId == loadUserData()?.memberId {
             cell.ghostButton.isHidden = true
             cell.verticalTextBarView.isHidden = true
-            self.deleteBottomsheet.warnButton.removeFromSuperview()
+            self.deleteReplyBottomsheet.warnButton.removeFromSuperview()
             
             cell.KebabButtonAction = {
-                print("나야")
-                self.deleteBottomsheet.showSettings()
-                self.deleteBottomsheet.deleteButton.addTarget(self, action: #selector(self.deletePost), for: .touchUpInside)
+                self.deleteReplyBottomsheet.showSettings()
+                self.deleteReplyBottomsheet.deleteButton.addTarget(self, action: #selector(self.deleteReply), for: .touchUpInside)
                 self.commentId = self.viewModel.postReplyData[indexPath.row].commentId
             }
         } else {
@@ -564,7 +625,6 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             self.warnBottomsheet.deleteButton.removeFromSuperview()
             
             cell.KebabButtonAction = {
-                print("너야")
                 self.warnBottomsheet.showSettings()
                 self.warnBottomsheet.warnButton.addTarget(self, action: #selector(self.warnUser), for: .touchUpInside)
                 self.commentId = self.viewModel.postReplyData[indexPath.row].commentId
@@ -632,12 +692,9 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             DispatchQueue.main.async {
                 self.postViewHeight = Int(header.PostbackgroundUIView.frame.height)
             }
-            // 내가 투명도를 누른 유저인 경우 -85% 적용
-            print("\(self.postView.isGhost)")
-            print("\(self.postView.memberGhost)")
             
+            // 내가 투명도를 누른 유저인 경우 -85% 적용
             if self.postView.isGhost {
-                print("header == \(header.grayView.alpha)")
                 header.grayView.alpha = 0.85
             } else {
                 let alpha = self.postView.memberGhost

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -78,7 +78,6 @@ final class PostViewController: UIViewController {
         setLayout()
         setDelegate()
         setTextFieldGesture()
-        setNotification()
         setRefreshControll()
         setRegister()
     }
@@ -100,13 +99,8 @@ final class PostViewController: UIViewController {
         super.viewWillAppear(animated)
         
         refreshPost()
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.didDismissDetailNotification(_:)),
-            name: NSNotification.Name("DismissReplyView"),
-            object: nil
-        )
+        
+        setNotification()
         
         self.navigationItem.hidesBackButton = true
         self.navigationItem.title = StringLiterals.Post.navigationTitleLabel
@@ -129,6 +123,7 @@ final class PostViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.backgroundColor = .clear
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name("likeButtonTapped"), object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("headerKebabButtonTapped"), object: nil)
     }
 }
 
@@ -184,13 +179,13 @@ extension PostViewController {
     }
     
     private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(self.didDismissDetailNotification(_:)), name: NSNotification.Name("DismissReplyView"), object: nil
+        )
         NotificationCenter.default.addObserver(self, selector: #selector(showToast(_:)), name: WriteReplyViewController.showUploadToastNotification, object: nil)
-        
         NotificationCenter.default.addObserver(self, selector: #selector(dismissViewController), name: CancelReplyPopupViewController.popViewController, object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector( self.likeButtonAction), name: NSNotification.Name("likeButtonTapped"), object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector( self.profileButtonAction), name: NSNotification.Name("profileButtonTapped"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.likeButtonAction), name: NSNotification.Name("likeButtonTapped"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.profileButtonAction), name: NSNotification.Name("profileButtonTapped"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.headerKebabButtonAction), name: NSNotification.Name("headerKebabButtonTapped"), object: nil)
     }
     
     @objc func didDismissDetailNotification(_ notification: Notification) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -679,6 +679,12 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             else { return UICollectionReusableView()
             }
             
+            if self.memberId == loadUserData()?.memberId {
+                header.ghostButton.isHidden = true
+            } else {
+                header.ghostButton.isHidden = false
+            }
+            
             header.transparentLabel.text = self.postView.transparentLabel.text
             header.postNicknameLabel.text = self.postView.postNicknameLabel.text
             header.timeLabel.text = self.postView.timeLabel.text

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostCollectionViewHeader.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostCollectionViewHeader.swift
@@ -290,6 +290,7 @@ extension PostCollectionViewHeader {
     func setAddTarget() {
         likeButton.addTarget(self, action: #selector(likeToggleButton), for: .touchUpInside)
         profileImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(profileImageCliked)))
+        kebabButton.addTarget(self, action: #selector(headerKebabButtonCliked), for: .touchUpInside)
     }
     
     @objc
@@ -307,5 +308,10 @@ extension PostCollectionViewHeader {
     @objc
     func profileImageCliked() {
         NotificationCenter.default.post(name: NSNotification.Name("profileButtonTapped"), object: nil, userInfo: nil)
+    }
+    
+    @objc
+    func headerKebabButtonCliked() {
+        NotificationCenter.default.post(name: NSNotification.Name("headerKebabButtonTapped"), object: nil, userInfo: nil)
     }
 }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 답글 달기 뷰에서 케밥버튼 분기 처리 완료했습니다
- 헤더뷰는 게시글 삭제, 아래 답글들은 답글 삭제로 분기 처리했습니다!
- 다른 사람의 게시글, 답글은 신고하기 바텀시트가 보이도록 했습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/21724380-58c2-44ec-bb46-968273f19e11" width ="250">|

## 📟 관련 이슈
- Resolved: #123 
