### PR TITLE
Feat [#119] 게시글 상세 UI 및 삭제 팝업 뷰 구현

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		2F0A98D32B58B8EF00AAE625 /* DeleteReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A98D22B58B8EF00AAE625 /* DeleteReplyViewController.swift */; };
 		2F1741882B500C270089FC4D /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741872B500C270089FC4D /* UIApplication+.swift */; };
 		2F17418A2B500CC20089FC4D /* HomeBottomsheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */; };
+		2F3182E52B5A3B2400E77EFD /* DontBeDeletePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3182E42B5A3B2400E77EFD /* DontBeDeletePopupView.swift */; };
 		2F40D5822B58364500AF68BC /* DeletePostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F40D5812B58364500AF68BC /* DeletePostViewModel.swift */; };
 		2F8735402B4BE65300E55552 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F87353F2B4BE65300E55552 /* HomeView.swift */; };
 		2F8735422B4BE66500E55552 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8735412B4BE66500E55552 /* HomeViewController.swift */; };
@@ -220,6 +221,7 @@
 		2F0A98D22B58B8EF00AAE625 /* DeleteReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteReplyViewController.swift; sourceTree = "<group>"; };
 		2F1741872B500C270089FC4D /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		2F1741892B500CC20089FC4D /* HomeBottomsheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomsheetView.swift; sourceTree = "<group>"; };
+		2F3182E42B5A3B2400E77EFD /* DontBeDeletePopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeDeletePopupView.swift; sourceTree = "<group>"; };
 		2F40D5812B58364500AF68BC /* DeletePostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePostViewModel.swift; sourceTree = "<group>"; };
 		2F87353F2B4BE65300E55552 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		2F8735412B4BE66500E55552 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -1055,6 +1057,7 @@
 				2AF069AF2B518B3F00CA3E48 /* UICollectionViewRegisterable.swift */,
 				3C0920DB2B4D78DA003BD080 /* DontBePopupView.swift */,
 				3C0920DD2B4D98CD003BD080 /* DontBeToastView.swift */,
+				2F3182E42B5A3B2400E77EFD /* DontBeDeletePopupView.swift */,
 				3CEE4CBC2B500A7800F506AF /* DontBeTransparencyInfoView.swift */,
 				3CEE4CC12B503F9E00F506AF /* DontBeCustomInfoView.swift */,
 				3C2F544D2B50F65500E7BF01 /* DontBeBottomSheetView.swift */,
@@ -1282,6 +1285,7 @@
 				2A5220EF2B507F97001510B7 /* NotificationViewModel.swift in Sources */,
 				2A84465C2B4EEC6C00F98F2A /* JoinProfileViewModel.swift in Sources */,
 				3CBCA3CC2B573F9000D348D3 /* MyPageProfileViewModel.swift in Sources */,
+				2F3182E52B5A3B2400E77EFD /* DontBeDeletePopupView.swift in Sources */,
 				2A5220F22B507FAE001510B7 /* NotificationTableViewCell.swift in Sources */,
 				3C2854FD2B3A9FD800369C99 /* ExampleViewController.swift in Sources */,
 				3CD25D292B5482FE0075F80F /* DontBeBottomSheetButton.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -67,6 +67,7 @@ enum StringLiterals {
         static let uploading = "게시 중..."
         static let uploaded = "게시 완료!"
         static let alreadyTransparency = "이미 투명도를 적용한 유저예요."
+        static let deleteText = "삭제 완료"
     }
     
     enum Notification {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeDeletePopupView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeDeletePopupView.swift
@@ -17,7 +17,7 @@ final class DontBeDeletePopupView: UIView {
     
     let container: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(red: 100, green: 100, blue: 100, alpha: 0.6)
+        view.backgroundColor = .donGray3
         view.layer.cornerRadius = 10.adjusted
         return view
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeDeletePopupView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBeDeletePopupView.swift
@@ -1,0 +1,68 @@
+//
+//  DontBeDeletePopupView.swift
+//  DontBe-iOS
+//
+//  Created by yeonsu on 1/19/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class DontBeDeletePopupView: UIView {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    let container: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 100, green: 100, blue: 100, alpha: 0.6)
+        view.layer.cornerRadius = 10.adjusted
+        return view
+    }()
+    
+    let toastLabel: UILabel = {
+        let label = UILabel()
+        label.text = StringLiterals.Toast.deleteText
+        label.textColor = .donBlack
+        label.textAlignment = .center
+        label.font = UIFont.font(.head3)
+        return label
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension DontBeDeletePopupView {
+    
+    private func setHierarchy() {
+        self.addSubview(container)
+        container.addSubviews(toastLabel)
+    }
+    
+    private func setLayout() {
+        container.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        toastLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/DeletePopupViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/DeletePopupViewController.swift
@@ -12,6 +12,8 @@ final class DeletePopupViewController: UIViewController {
     
     static let popViewController = NSNotification.Name("popVC")
     static let reloadData = NSNotification.Name("reloadData")
+    static let showWriteToastNotification = Notification.Name("ShowWriteToastNotification")
+    static let showDeleteToastNotification = Notification.Name("ShowDeleteToastNotification")
     
     // MARK: - Properties
     var contentId: Int = 0
@@ -41,7 +43,7 @@ final class DeletePopupViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setUI()
         setHierarchy()
         setLayout()
@@ -56,6 +58,8 @@ final class DeletePopupViewController: UIViewController {
         super.viewWillDisappear(animated)
         
         NotificationCenter.default.post(name: NSNotification.Name("DismissDetailView"), object: nil, userInfo: nil)
+        
+        NotificationCenter.default.post(name: DeletePopupViewController.showDeleteToastNotification, object: nil, userInfo: ["showDeleteToast": true])
     }
     
     init(viewModel: DeletePostViewModel) {
@@ -123,6 +127,7 @@ extension DeletePopupViewController: DontBePopupDelegate {
     
     func confirmButtonTapped() {
         self.homeVC.refreshPost()
+        
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -37,8 +37,10 @@ final class HomeViewController: UIViewController {
     
     private let myView = HomeView()
     lazy var homeCollectionView = HomeCollectionView().collectionView
+    private var deleteToastView: DontBeDeletePopupView?
     private var uploadToastView: DontBeToastView?
     private var alreadyTransparencyToastView: DontBeToastView?
+    
     
     // MARK: - Life Cycles
     
@@ -162,6 +164,7 @@ extension HomeViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(showToast(_:)), name: WriteViewController.showWriteToastNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showDeleteToast(_:)), name: DeletePopupViewController.showDeleteToastNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(popViewController), name: DeletePopupViewController.popViewController, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.didDismissPopupNotification(_:)), name: NSNotification.Name("DismissDetailView"), object: nil)
     }
@@ -236,6 +239,28 @@ extension HomeViewController {
                         self.uploadToastView?.checkImageView.alpha = 0
                         self.uploadToastView?.toastLabel.text = StringLiterals.Toast.uploading
                         self.uploadToastView?.container.backgroundColor = .donGray3
+                    }
+                }
+            }
+        }
+    }
+    
+    @objc func showDeleteToast(_ notification: Notification) {
+        if let showToast = notification.userInfo?["showDeleteToast"] as? Bool {
+            if showToast == true {
+                DispatchQueue.main.async {
+                    self.deleteToastView = DontBeDeletePopupView()
+                    
+                    self.view.addSubviews(self.deleteToastView ?? DontBeDeletePopupView())
+                    
+                    self.deleteToastView?.snp.makeConstraints {
+                        $0.leading.trailing.equalToSuperview().inset(24.adjusted)
+                        $0.centerY.equalTo(self.view.safeAreaLayoutGuide)
+                        $0.height.equalTo(75.adjusted)
+                    }
+                    
+                    UIView.animate(withDuration: 2.0, delay: 0, options: .curveEaseIn) {
+                        self.deleteToastView?.alpha = 0
                     }
                 }
             }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
@@ -143,6 +143,18 @@ final class PostReplyCollectionViewCell: UICollectionViewCell, UICollectionViewR
         view.layer.cornerRadius = 6.adjusted
         return view
     }()
+    
+    private let verticalBarView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .donGray3
+        return view
+    }()
+    
+    private let cellSpacingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .donGray1
+        return view
+    }()
 
     // MARK: - Life Cycles
     
@@ -171,6 +183,7 @@ extension PostReplyCollectionViewCell {
         contentView.addSubviews(horizontalCellBarCircleView,
                                 backgroundUIView,
                                 horizontalCellBarView,
+                                verticalBarView,
                                 grayView)
         
         backgroundUIView.addSubviews(profileImageView,
@@ -182,7 +195,8 @@ extension PostReplyCollectionViewCell {
                                      contentTextLabel,
                                      likeStackView,
                                      ghostButton,
-                                     verticalTextBarView)
+                                     verticalTextBarView,
+                                     cellSpacingView)
         
         likeStackView.addArrangedSubviews(likeButton,
                                           likeNumLabel)
@@ -207,7 +221,8 @@ extension PostReplyCollectionViewCell {
             $0.centerY.equalTo(backgroundUIView)
             $0.trailing.equalTo(backgroundUIView.snp.leading)
             $0.height.equalTo(1.adjusted)
-            $0.leading.equalToSuperview().inset(-18.adjusted)
+            $0.width.equalTo(22.adjusted)
+            $0.leading.equalToSuperview()
         }
         
         horizontalCellBarCircleView.snp.makeConstraints {
@@ -272,6 +287,18 @@ extension PostReplyCollectionViewCell {
             $0.bottom.equalTo(ghostButton.snp.top)
             $0.width.equalTo(1.adjusted)
             $0.centerX.equalTo(profileImageView)
+        }
+        
+        verticalBarView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.trailing.equalTo(horizontalCellBarView.snp.leading)
+            $0.width.equalTo(1)
+        }
+        
+        cellSpacingView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.width.equalTo(backgroundUIView)
+            $0.height.equalTo(8)
         }
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/DeleteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/DeleteReplyViewController.swift
@@ -13,6 +13,7 @@ final class DeleteReplyViewController: UIViewController {
     // MARK: - Properties
     
     static let reloadData = NSNotification.Name("reloadData")
+    static let showDeleteToastNotification = Notification.Name("ShowDeleteToastNotification")
     var commentId: Int = 0
     var viewModel: DeleteReplyViewModel
     private var cancelBag = CancelBag()
@@ -54,10 +55,11 @@ final class DeleteReplyViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        print("안녀어엉")
 
         NotificationCenter.default.post(name: NSNotification.Name("DismissDetailView"), object: nil, userInfo: nil)
-
         NotificationCenter.default.post(name: NSNotification.Name("DismissReplyView"), object: nil, userInfo: nil)
+        NotificationCenter.default.post(name: DeleteReplyViewController.showDeleteToastNotification, object: nil, userInfo: ["showDeleteToast": true])
     }
 
     init(viewModel: DeleteReplyViewModel) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -180,6 +180,7 @@ extension PostViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(self.likeButtonAction), name: NSNotification.Name("likeButtonTapped"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.profileButtonAction), name: NSNotification.Name("profileButtonTapped"), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.headerKebabButtonAction), name: NSNotification.Name("headerKebabButtonTapped"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showDeleteToast(_:)), name: DeleteReplyViewController.showDeleteToastNotification, object: nil)
     }
     
     @objc func didDismissDetailNotification(_ notification: Notification) {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -65,26 +65,19 @@ final class PostViewController: UIViewController {
     private var uploadToastView: DontBeToastView?
     private var alreadyTransparencyToastView: DontBeToastView?
     
-    private let verticalBarView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .donGray3
-        return view
-    }()
-    
     // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
         setAddTarget()
         setUI()
         setHierarchy()
-        setLayout()
         setDelegate()
         setTextFieldGesture()
         setRefreshControll()
         setRegister()
+        setLayout()
     }
     
     init(viewModel: PostViewModel) {
@@ -121,7 +114,9 @@ final class PostViewController: UIViewController {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(56.adjusted)
         }
+        
         getAPI()
+        
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -145,7 +140,6 @@ extension PostViewController {
     
     private func setHierarchy() {
         view.addSubviews(grayView,
-                         verticalBarView,
                          postReplyCollectionView,
                          textFieldView)
     }
@@ -161,13 +155,6 @@ extension PostViewController {
             $0.top.equalTo(self.view.safeAreaLayoutGuide)
             $0.bottom.equalTo(textFieldView.snp.bottom).offset(-56.adjusted)
             $0.leading.trailing.equalToSuperview()
-        }
-        
-        verticalBarView.snp.makeConstraints {
-            $0.top.equalTo(postReplyCollectionView)
-            $0.leading.equalToSuperview().inset(16.adjusted)
-            $0.width.equalTo(1.adjusted)
-            $0.bottom.equalTo(postReplyCollectionView.snp.bottom)
         }
         
         textFieldView.snp.makeConstraints {
@@ -528,6 +515,8 @@ extension PostViewController {
             .receive(on: RunLoop.main)
             .sink { data in
                 self.postReplyCollectionView.reloadData()
+                
+                print("\(self.collectionHeaderView.frame.height)")
             }
             .store(in: self.cancelBag)
     }
@@ -694,7 +683,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             header.isLiked = self.postView.isLiked
             header.likeButton.setImage(header.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
             header.ghostButton.addTarget(self, action: #selector(transparentShowPopupButton), for: .touchUpInside)
-
+            
             DispatchQueue.main.async {
                 self.postViewHeight = Int(header.PostbackgroundUIView.frame.height)
             }
@@ -723,7 +712,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         
-        return CGSize(width: UIScreen.main.bounds.width, height: 8 + postViewHeight.adjusted)
+        return CGSize(width: UIScreen.main.bounds.width, height: 1 + postViewHeight.adjusted)
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -64,6 +64,7 @@ final class PostViewController: UIViewController {
     private lazy var greenTextField = textFieldView.greenTextFieldView
     private var uploadToastView: DontBeToastView?
     private var alreadyTransparencyToastView: DontBeToastView?
+    private var deleteToastView: DontBeDeletePopupView?
     
     // MARK: - Life Cycles
     
@@ -124,6 +125,7 @@ final class PostViewController: UIViewController {
         self.navigationController?.navigationBar.backgroundColor = .clear
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name("likeButtonTapped"), object: nil)
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name("headerKebabButtonTapped"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showDeleteToast(_:)), name: DeletePopupViewController.showDeleteToastNotification, object: nil)
     }
 }
 
@@ -380,6 +382,29 @@ extension PostViewController {
         }
     }
     
+    @objc 
+    func showDeleteToast(_ notification: Notification) {
+            if let showToast = notification.userInfo?["showDeleteToast"] as? Bool {
+                if showToast == true {
+                    DispatchQueue.main.async {
+                        self.deleteToastView = DontBeDeletePopupView()
+                        
+                        self.view.addSubviews(self.deleteToastView ?? DontBeDeletePopupView())
+                        
+                        self.deleteToastView?.snp.makeConstraints {
+                            $0.leading.trailing.equalToSuperview().inset(24.adjusted)
+                            $0.centerY.equalTo(self.view.safeAreaLayoutGuide)
+                            $0.height.equalTo(75.adjusted)
+                        }
+                        
+                        UIView.animate(withDuration: 2.0, delay: 0, options: .curveEaseIn) {
+                            self.deleteToastView?.alpha = 0
+                        }
+                    }
+                }
+            }
+        }
+    
     func popPostView() {
         if UIApplication.shared.keyWindowInConnectedScenes != nil {
             UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
@@ -515,8 +540,6 @@ extension PostViewController {
             .receive(on: RunLoop.main)
             .sink { data in
                 self.postReplyCollectionView.reloadData()
-                
-                print("\(self.collectionHeaderView.frame.height)")
             }
             .store(in: self.cancelBag)
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyCollectionView.swift
@@ -13,8 +13,8 @@ final class PostReplyCollectionView: UIView {
     
     lazy var collectionView: UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
-        flowLayout.minimumLineSpacing = 10.adjusted
-        flowLayout.minimumInteritemSpacing = 10.adjusted
+        flowLayout.minimumLineSpacing = 0.adjusted
+        flowLayout.minimumInteritemSpacing = 0.adjusted
         flowLayout.scrollDirection = .vertical
         flowLayout.estimatedItemSize = CGSize(width: 200.adjusted, height: 160.adjusted)
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyPostView.swift
@@ -12,6 +12,7 @@ import SnapKit
 final class WriteReplyPostView: UIView {
 
     // MARK: - Properties
+    var detailViewHeight: Int = 0
     
     // MARK: - UI Components
     
@@ -58,6 +59,7 @@ final class WriteReplyPostView: UIView {
         setLayout()
         setAddTarget()
         setRegisterCell()
+        saveHeight()
     }
     
     @available(*, unavailable)
@@ -112,8 +114,8 @@ extension WriteReplyPostView {
         
     }
     
-    private func setDataBind() {
-        
+    private func saveHeight() {
+        detailViewHeight = Int(self.backgroundUIView.frame.height)
     }
 }
 


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 게시글 상세 UI 수정했습니다.
- 게시글 / 답글 삭제 시 팝업 뷰 띄우기 구현했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/a26900ca-06f2-4a52-928d-526bbc4691ce" width ="250">|

## 📟 관련 이슈
- Resolved: #119
