### PR TITLE
Fix [#130] 프로그레스바 줄어들지 않는 현상, 댓글 순서 변경, 투명도 적용 시 값 전달 변경

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -354,13 +354,6 @@ extension HomeViewController: UICollectionViewDelegate { }
 
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let sortedData = viewModel.postData.sorted {
-            $0.time.compare($1.time, options: .numeric) == .orderedDescending
-        }
-        
-        // Replace the viewModel.postData array with the sortedData
-        viewModel.postData = sortedData
-        
         return viewModel.postData.count
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -217,9 +217,6 @@ extension MyPageCommentViewController: UICollectionViewDelegate { }
 
 extension MyPageCommentViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let sortedData = commentData.sorted { $0.time.compare($1.time, options: .numeric) == .orderedDescending }
-        
-        commentData = sortedData
         return commentData.count
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -226,7 +226,7 @@ extension MyPageCommentViewController: UICollectionViewDataSource, UICollectionV
         
         cell.alarmTriggerType = "commentGhost"
         cell.targetMemberId = commentData[indexPath.row].memberId
-        cell.alarmTriggerdId = commentData[indexPath.row].contentId
+        cell.alarmTriggerdId = commentData[indexPath.row].commentId
         
         if commentData[indexPath.row].memberId == loadUserData()?.memberId {
             cell.ghostButton.isHidden = true

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageContentViewController.swift
@@ -228,9 +228,6 @@ extension MyPageContentViewController: UICollectionViewDelegate { }
 
 extension MyPageContentViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let sortedData = contentData.sorted { $0.time.compare($1.time, options: .numeric) == .orderedDescending }
-        
-        self.contentData = sortedData
         return self.contentData.count
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -598,11 +598,6 @@ extension PostViewController {
 
 extension PostViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let sortedData = viewModel.postReplyData.sorted {
-            $0.time.compare($1.time, options: .numeric) == .orderedDescending
-        }
-        
-        viewModel.postReplyData = sortedData
         return viewModel.postReplyData.count
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -607,7 +607,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
 
         cell.alarmTriggerType = "commentGhost"
         cell.targetMemberId = viewModel.postReplyData[indexPath.row].memberId
-        cell.alarmTriggerdId = self.contentId
+        cell.alarmTriggerdId = viewModel.postReplyData[indexPath.row].commentId
         cell.nicknameLabel.text = viewModel.postReplyData[indexPath.row].memberNickname
         
         if viewModel.postReplyData[indexPath.row].memberId == loadUserData()?.memberId {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift
@@ -41,6 +41,7 @@ final class PostViewController: UIViewController {
     var contentId: Int = 0
     var commentId: Int = 0
     var memberId: Int = 0
+    var postMemberId: Int = 0
     var alarmTriggerType: String = ""
     var targetMemberId: Int = 0
     var alarmTriggerdId: Int = 0
@@ -277,7 +278,7 @@ extension PostViewController {
     
     @objc
     func deleteOrWarn() {
-        if self.memberId == loadUserData()?.memberId ?? 0 {
+        if self.postMemberId == loadUserData()?.memberId ?? 0 {
             self.deleteReplyBottomsheet.showSettings()
             addDeleteReplyButtonAction()
         } else {
@@ -311,7 +312,7 @@ extension PostViewController {
     
     @objc
     func headerKebabButtonAction() {
-        if self.memberId == loadUserData()?.memberId ?? 0 {
+        if self.postMemberId == loadUserData()?.memberId ?? 0 {
             self.deletePostBottomsheet.showSettings()
             addDeletePostButtonAction()
         } else {
@@ -356,6 +357,28 @@ extension PostViewController {
     
     @objc
     private func pushToMypage() {
+        if self.postMemberId == loadUserData()?.memberId ?? 0  {
+            self.tabBarController?.selectedIndex = 3
+            if let selectedViewController = self.tabBarController?.selectedViewController {
+                self.applyTabBarAttributes(to: selectedViewController.tabBarItem, isSelected: true)
+            }
+            let myViewController = self.tabBarController?.viewControllers ?? [UIViewController()]
+            for (index, controller) in myViewController.enumerated() {
+                if let tabBarItem = controller.tabBarItem {
+                    if index != self.tabBarController?.selectedIndex {
+                        self.applyTabBarAttributes(to: tabBarItem, isSelected: false)
+                    }
+                }
+            }
+        } else {
+            let viewController = MyPageViewController(viewModel: MyPageViewModel(networkProvider: NetworkService()))
+            viewController.memberId = postMemberId
+            self.navigationController?.pushViewController(viewController, animated: false)
+        }
+    }
+    
+    @objc
+    private func pushToOtherUserPage() {
         if self.memberId == loadUserData()?.memberId ?? 0  {
             self.tabBarController?.selectedIndex = 3
             if let selectedViewController = self.tabBarController?.selectedViewController {
@@ -523,7 +546,7 @@ extension PostViewController {
         output.getPostData
             .receive(on: RunLoop.main)
             .sink { data in
-                self.memberId = data.memberId
+                self.postMemberId = data.memberId
                 self.bindPostData(data: data)
                 self.postReplyCollectionView.reloadData()
                 self.perform(#selector(self.finishedRefreshing), with: nil, afterDelay: 0.1)
@@ -555,7 +578,7 @@ extension PostViewController {
         self.postView.commentNumLabel.text = "\(data.commentNumber)"
         self.postView.profileImageView.load(url: "\(data.memberProfileUrl)")
         postView.likeButton.setImage(data.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
-        self.memberId = data.memberId
+        self.postMemberId = data.memberId
         self.postView.profileImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(pushToMypage)))
         self.postView.isLiked = data.isLiked
         
@@ -570,7 +593,7 @@ extension PostViewController {
             self.collectionHeaderView?.grayView.alpha = CGFloat(Double(-alpha) / 100)
         }
         
-        if self.memberId == loadUserData()?.memberId {
+        if self.postMemberId == loadUserData()?.memberId {
             self.postView.ghostButton.isHidden = true
             self.postView.verticalTextBarView.isHidden = true
         } else {
@@ -650,7 +673,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
         }
         cell.ProfileButtonAction = {
             self.memberId = self.viewModel.postReplyData[indexPath.row].memberId
-            self.pushToMypage()
+            self.pushToOtherUserPage()
         }
         cell.nicknameLabel.text = viewModel.postReplyData[indexPath.row].memberNickname
         cell.transparentLabel.text = "투명도 \(viewModel.postReplyData[indexPath.row].memberGhost)%"
@@ -680,7 +703,7 @@ extension PostViewController: UICollectionViewDataSource, UICollectionViewDelega
             else { return UICollectionReusableView()
             }
             
-            if self.memberId == loadUserData()?.memberId {
+            if self.postMemberId == loadUserData()?.memberId {
                 header.ghostButton.isHidden = true
                 header.verticalTextBarView.isHidden = true
             } else {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -199,6 +199,8 @@ extension WriteTextView: UITextViewDelegate {
         let textLength = contentTextView.text.count
         textView.text = String(textView.text.prefix(maxLength))
         if textLength == 0 {
+            let value = Double(textLength) / 500
+            circleProgressBar.value = value
             postButton.setTitleColor(.donGray9, for: .normal)
             postButton.backgroundColor = .donGray3
             postButton.isEnabled = false

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -38,10 +38,13 @@ final class WriteTextView: UIView {
         textView.tintColor = .donPrimary
         textView.backgroundColor = .clear
         textView.addPlaceholder(StringLiterals.Write.writeContentPlaceholder, padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
-        textView.textContainerInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        textView.textContainerInset = UIEdgeInsets(top: 0, left: 0, bottom: 100, right: 0)
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainer.lineBreakMode = .byWordWrapping
         textView.textContainer.maximumNumberOfLines = 0
+        textView.isScrollEnabled = true
+        textView.isEditable = true
+        textView.showsVerticalScrollIndicator = false
         return textView
     }()
     
@@ -221,6 +224,7 @@ extension WriteTextView: UITextViewDelegate {
                 limitedCircleProgressBar.alpha = 1
                 circleProgressBar.alpha = 0
                 postButton.isEnabled = false
+                postButton.setTitleColor(.donGray9, for: .normal)
                 postButton.backgroundColor = .donGray3
                 impactFeedbackGenerator.impactOccurred()
             }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 프로그레스바가 줄어들지 않는 오류 해결했습니다! ProgressBar value 가 0인 경우에 값 전달을 하는 코드를 빼먹었었습니다!!ㅎㅎ
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/1960e2b6225dc4b5bc44174d23b0d3f19ddfc087/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift#L197-L206

- 댓글 순서를 서버에서 이미 정렬을 해주기 때문에 저희가 따로 정렬을 할 필요가 없어서 sorted 관련 함수 모두 삭제했습니다!
- 기존에 collectionView 아래 코드에 있던 sorted 해주는 코드 삭제
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/1960e2b6225dc4b5bc44174d23b0d3f19ddfc087/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift#L356-L358

- 댓글에서 투명도 버튼을 클릭 시, 기존에는 서버측에서 그 댓글이 달린 게시물의 id 값을 요청했었는데, 로직 상 문제가 있다고 그래서 다시 commentId 어떤 댓글을 눌렀는지 전달해주는 값으로 변경했습니다!!
- commentGhost 인 경우, commentId 값을 전달해주는 것으로 변경
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/1960e2b6225dc4b5bc44174d23b0d3f19ddfc087/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostViewController.swift#L604-L611

- 게시물 상세보기에서 프로필 사진 클릭 시, 다른 유저로 이동하는 오류 해결했습니다!
- memberId 가 댓글의 memberId와 게시물의 memberId를 하나의 변수로 공유하고 있기 때문에 생긴 오류였습니다!
- postMemberId: 게시물 쓴 사람의 memberId, 기존의 memberId: 댓글들의 memberId 로 통일하겠습니다!

## 📟 관련 이슈
- Resolved: #130 
