### PR TITLE
Feat [#143] 로그아웃 및 애플로그인 기능 구현

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		2AAEFC982B4A9E3B00C2D323 /* DontBeTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeTabBarController.swift; sourceTree = "<group>"; };
 		2AC9FB1A2B4DE77400D31071 /* AgreementListCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementListCustomView.swift; sourceTree = "<group>"; };
 		2AC9FB1E2B4E634A00D31071 /* JoinAgreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinAgreeView.swift; sourceTree = "<group>"; };
+		2AE95D702B81EC52009C6336 /* DontBe-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "DontBe-iOS.entitlements"; sourceTree = "<group>"; };
 		2AF069AD2B514B0100CA3E48 /* NotificationEmptyViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEmptyViewCell.swift; sourceTree = "<group>"; };
 		2AF069AF2B518B3F00CA3E48 /* UICollectionViewRegisterable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewRegisterable.swift; sourceTree = "<group>"; };
 		2AF069B12B518F8E00CA3E48 /* MyPageNicknameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageNicknameEditView.swift; sourceTree = "<group>"; };
@@ -747,6 +748,7 @@
 		3C6192EB2B3A719A00220CEB /* DontBe-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				2AE95D702B81EC52009C6336 /* DontBe-iOS.entitlements */,
 				3C6193002B3A771E00220CEB /* Application */,
 				3C6193012B3A772B00220CEB /* Global */,
 				3C6193022B3A773100220CEB /* Network */,
@@ -1465,12 +1467,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DontBe-iOS/DontBe-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = MAZQ6JDBT4;
+				DEVELOPMENT_TEAM = MAZQ6JDBT4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DontBe-iOS/Global/Resources/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Don't Be";
@@ -1487,7 +1488,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SOPT33.DontBe-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "DontBe-Debug";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1502,12 +1502,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "DontBe-iOS/DontBe-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = MAZQ6JDBT4;
+				DEVELOPMENT_TEAM = MAZQ6JDBT4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DontBe-iOS/Global/Resources/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Don't Be";
@@ -1524,7 +1523,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SOPT33.DontBe-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "DontBe-Release";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/DontBe-iOS/DontBe-iOS/DontBe-iOS.entitlements
+++ b/DontBe-iOS/DontBe-iOS/DontBe-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/DontBe-iOS/DontBe-iOS/Network/SocialLogin/DTO/RequestDTO/SocialLoginRequestDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/SocialLogin/DTO/RequestDTO/SocialLoginRequestDTO.swift
@@ -11,4 +11,5 @@ import Foundation
 
 struct SocialLoginRequestDTO: Encodable {
     let socialPlatform: String
+    let userName: String?
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -15,7 +15,7 @@ final class LoginViewController: UIViewController {
     
     private var cancelBag = CancelBag()
     private let viewModel: LoginViewModel
-    private lazy var loginButtonTapped = self.loginButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
+    private lazy var loginButtonTapped = self.kakaoLoginButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
     
     // MARK: - UI Components
     
@@ -35,9 +35,15 @@ final class LoginViewController: UIViewController {
         return title
     }()
     
-    private let loginButton: UIButton = {
+    private let kakaoLoginButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Login.btnKakao, for: .normal)
+        return button
+    }()
+    
+    private let appleLoginButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.loginBtnApple, for: .normal)
         return button
     }()
     
@@ -79,8 +85,8 @@ extension LoginViewController {
     private func setHierarchy() {
         self.view.addSubviews(loginLogo,
                               loginTitle,
-                              loginButton)
-        
+                              kakaoLoginButton,
+                              appleLoginButton)
     }
     
     private func setLayout() {
@@ -96,13 +102,23 @@ extension LoginViewController {
             $0.leading.equalToSuperview().inset(26.adjusted)
         }
         
-        loginButton.snp.makeConstraints {
+        kakaoLoginButton.snp.makeConstraints {
+            $0.bottom.equalTo(appleLoginButton.snp.top).offset(-10.adjusted)
+            $0.leading.trailing.equalToSuperview().inset(18.adjusted)
+            $0.height.equalTo(50.adjusted)
+        }
+        
+        appleLoginButton.snp.makeConstraints {
             $0.bottom.equalTo(self.view.safeAreaLayoutGuide).inset(51.adjusted)
             $0.leading.trailing.equalToSuperview().inset(18.adjusted)
             $0.height.equalTo(50.adjusted)
         }
         
-        loginButton.imageView?.snp.makeConstraints {
+        kakaoLoginButton.imageView?.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        appleLoginButton.imageView?.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -125,10 +125,10 @@ extension LoginViewController {
     }
     
     private func bindViewModel() {
-        let kakaoInput = LoginViewModel.Input(kakaoButtonTapped: kakaoButtonTapped, appleButtonTapped: nil)
-        let kakaoOutput = self.viewModel.transform(from: kakaoInput, cancelBag: self.cancelBag)
+        let input = LoginViewModel.Input(kakaoButtonTapped: kakaoButtonTapped, appleButtonTapped: appleButtonTapped)
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
-        kakaoOutput.userInfoPublisher
+        output.userInfoPublisher
             .receive(on: RunLoop.main)
             .sink { value in
                 if value {
@@ -139,26 +139,6 @@ extension LoginViewController {
                     let viewController = OnboardingViewController()
                         viewController.originView.isFirstUser = false
                         self.navigationController?.pushViewController(viewController, animated: true)
-                }
-            }
-            .store(in: self.cancelBag)
-        
-        let appleInput = LoginViewModel.Input(kakaoButtonTapped: nil, appleButtonTapped: appleButtonTapped)
-        let appleOutput = self.viewModel.transform(from: appleInput, cancelBag: self.cancelBag)
-        
-        appleOutput.userInfoPublisher
-            .receive(on: RunLoop.main)
-            .sink { value in
-                if value {
-                    if value {
-                        // 첫 로그인 유저면 여기
-                        let viewController = JoinAgreementViewController(viewModel: JoinAgreeViewModel())
-                        self.navigationController?.pushViewController(viewController, animated: true)
-                    } else {
-                        let viewController = OnboardingViewController()
-                            viewController.originView.isFirstUser = false
-                            self.navigationController?.pushViewController(viewController, animated: true)
-                    }
                 }
             }
             .store(in: self.cancelBag)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -141,7 +141,8 @@ extension LoginViewModel {
             return data
         }
         catch {
-           return nil
+            print(error)
+            return nil
        }
     }
 }
@@ -156,9 +157,7 @@ extension LoginViewModel: ASAuthorizationControllerDelegate {
         if let fullName = credential.fullName,
            let identifyToken = credential.identityToken {
             let userName = (fullName.familyName ?? "") + (fullName.givenName ?? "")
-            print(userName)
             let accessToken = String(data: identifyToken, encoding: .utf8)
-            print(accessToken ?? "")
             // 애플로그인 서버통신
             Task {
                 do {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -430,6 +430,14 @@ extension MyPageViewController {
                               isOnboardingFinished: true,
                               userNickname: loadUserData()?.userNickname ?? "",
                               memberId: loadUserData()?.memberId ?? 0))
+        // KeychainWrapper에 Access Token 저장하고 소셜로그인 화면으로
+        let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") ?? ""
+        KeychainWrapper.saveToken(accessToken, forKey: "accessToken")
+        
+        // KeychainWrasapper에 Refresh Token 저장하고 소셜로그인 화면으로
+        let refreshToken = KeychainWrapper.loadToken(forKey: "refreshToken") ?? ""
+        KeychainWrapper.saveToken(refreshToken, forKey: "refreshToken")
+
     }
     
     @objc

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -418,7 +418,18 @@ extension MyPageViewController {
     @objc
     private func logoutButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
-        print("logoutButtonTapped")
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            DispatchQueue.main.async {
+                let rootViewController = LoginViewController(viewModel: LoginViewModel(networkProvider: NetworkService()))
+                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: rootViewController)
+            }
+        }
+        saveUserData(UserInfo(isSocialLogined: false,
+                              isFirstUser: false,
+                              isJoinedApp: true,
+                              isOnboardingFinished: true,
+                              userNickname: loadUserData()?.userNickname ?? "",
+                              memberId: loadUserData()?.memberId ?? 0))
     }
     
     @objc


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 로그아웃 및 애플로그인 기능을 구현하였습니다 !

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 애플로그인 관련 로직을 추가하였습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/d74ab4545716a9ffaa8854e91ed92e3972bdb6b3/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift#L149-L183
- 소셜로그인 서버통신은 전과 같이 하나의 함수에서 진행해주었습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/d74ab4545716a9ffaa8854e91ed92e3972bdb6b3/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift#L104-L147
## 📸 스크린샷
https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/97782228/e01218d6-3221-41be-9104-f8eb75769be0


## 📟 관련 이슈
- Resolved: #143 
