### PR TITLE
Network [#144] 계정 삭제 API 연동 구현 완료

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		3C4993672B4F2644002A99CF /* MyPageContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4993662B4F2644002A99CF /* MyPageContentViewController.swift */; };
 		3C4993692B4F2653002A99CF /* MyPageCommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4993682B4F2653002A99CF /* MyPageCommentViewController.swift */; };
 		3C4EDCCB2B58653800A9707C /* PostReplyResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4EDCCA2B58653800A9707C /* PostReplyResponseDTO.swift */; };
+		3C4F5BB52B7A49A500B21C45 /* MyPageSignOutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F5BB42B7A49A500B21C45 /* MyPageSignOutViewController.swift */; };
+		3C4F5BB72B7A4A0C00B21C45 /* MyPageSignOutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4F5BB62B7A4A0C00B21C45 /* MyPageSignOutView.swift */; };
 		3C6192ED2B3A719A00220CEB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6192EC2B3A719A00220CEB /* AppDelegate.swift */; };
 		3C6192EF2B3A719A00220CEB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6192EE2B3A719A00220CEB /* SceneDelegate.swift */; };
 		3C6192F62B3A719C00220CEB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C6192F52B3A719C00220CEB /* Assets.xcassets */; };
@@ -254,6 +256,8 @@
 		3C4993662B4F2644002A99CF /* MyPageContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageContentViewController.swift; sourceTree = "<group>"; };
 		3C4993682B4F2653002A99CF /* MyPageCommentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCommentViewController.swift; sourceTree = "<group>"; };
 		3C4EDCCA2B58653800A9707C /* PostReplyResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReplyResponseDTO.swift; sourceTree = "<group>"; };
+		3C4F5BB42B7A49A500B21C45 /* MyPageSignOutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageSignOutViewController.swift; sourceTree = "<group>"; };
+		3C4F5BB62B7A4A0C00B21C45 /* MyPageSignOutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageSignOutView.swift; sourceTree = "<group>"; };
 		3C6192E92B3A719A00220CEB /* DontBe-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DontBe-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C6192EC2B3A719A00220CEB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3C6192EE2B3A719A00220CEB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -1085,6 +1089,7 @@
 				3C4993642B4F2471002A99CF /* MyPageSegmentedControl.swift */,
 				2AF069B12B518F8E00CA3E48 /* MyPageNicknameEditView.swift */,
 				2AF069B32B5194F300CA3E48 /* MyPageIntroductionEditView.swift */,
+				3C4F5BB62B7A4A0C00B21C45 /* MyPageSignOutView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1097,6 +1102,7 @@
 				3C4993682B4F2653002A99CF /* MyPageCommentViewController.swift */,
 				3C2F544F2B51223200E7BF01 /* MyPageEditProfileViewController.swift */,
 				3C2F54512B51224500E7BF01 /* MyPageAccountInfoViewController.swift */,
+				3C4F5BB42B7A49A500B21C45 /* MyPageSignOutViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -1207,6 +1213,7 @@
 				2A8868D62B5069790017513A /* OnboardingEndingView.swift in Sources */,
 				2A8D70BD2B4D61A1009F4C6C /* OnboardingDummy.swift in Sources */,
 				3C6193152B3A7A6400220CEB /* UIView+.swift in Sources */,
+				3C4F5BB72B7A4A0C00B21C45 /* MyPageSignOutView.swift in Sources */,
 				2AC9FB1F2B4E634A00D31071 /* JoinAgreeView.swift in Sources */,
 				2F05B1B42B57F15B00AC368D /* WriteReplyViewModel.swift in Sources */,
 				3CBCA3CA2B57212400D348D3 /* MyPageMemberCommentResponseDTO.swift in Sources */,
@@ -1247,6 +1254,7 @@
 				3CE9C12C2B4BE7300086E4A3 /* WriteView.swift in Sources */,
 				3C2F54502B51223200E7BF01 /* MyPageEditProfileViewController.swift in Sources */,
 				2A6D54C32B493A8400F9891E /* UIFont+.swift in Sources */,
+				3C4F5BB52B7A49A500B21C45 /* MyPageSignOutViewController.swift in Sources */,
 				2A0A73192B5497AE004478C1 /* TokenManager.swift in Sources */,
 				3C4993692B4F2653002A99CF /* MyPageCommentViewController.swift in Sources */,
 				2A2671F72B4BEA34009D214F /* LoginViewController.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		3C70BE332B53EF92001AA5A6 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */; };
 		3C7741522B5311750069E694 /* MyPageAccountInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */; };
 		3C7741542B531AC80069E694 /* AccountInfoDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7741532B531AC80069E694 /* AccountInfoDummy.swift */; };
+		3CA32F532B81E200003DF637 /* MyPageAccountInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA32F522B81E200003DF637 /* MyPageAccountInfoViewModel.swift */; };
 		3CB634CA2B59080E00DB9DA5 /* DontBeTransparencyGrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB634C92B59080E00DB9DA5 /* DontBeTransparencyGrayView.swift */; };
 		3CBCA3CA2B57212400D348D3 /* MyPageMemberCommentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCA3C92B57212400D348D3 /* MyPageMemberCommentResponseDTO.swift */; };
 		3CBCA3CC2B573F9000D348D3 /* MyPageProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCA3CB2B573F9000D348D3 /* MyPageProfileViewModel.swift */; };
@@ -274,6 +275,7 @@
 		3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		3C7741512B5311750069E694 /* MyPageAccountInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAccountInfoTableViewCell.swift; sourceTree = "<group>"; };
 		3C7741532B531AC80069E694 /* AccountInfoDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoDummy.swift; sourceTree = "<group>"; };
+		3CA32F522B81E200003DF637 /* MyPageAccountInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAccountInfoViewModel.swift; sourceTree = "<group>"; };
 		3CB634C92B59080E00DB9DA5 /* DontBeTransparencyGrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DontBeTransparencyGrayView.swift; sourceTree = "<group>"; };
 		3CBCA3C92B57212400D348D3 /* MyPageMemberCommentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageMemberCommentResponseDTO.swift; sourceTree = "<group>"; };
 		3CBCA3CB2B573F9000D348D3 /* MyPageProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageProfileViewModel.swift; sourceTree = "<group>"; };
@@ -974,6 +976,7 @@
 			children = (
 				3C70BE322B53EF92001AA5A6 /* MyPageViewModel.swift */,
 				3CBCA3CB2B573F9000D348D3 /* MyPageProfileViewModel.swift */,
+				3CA32F522B81E200003DF637 /* MyPageAccountInfoViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1208,6 +1211,7 @@
 				3C6193172B3A7A7B00220CEB /* UIStackView+.swift in Sources */,
 				2A73415C2B58534400F65FD0 /* ContentLikeRequestDTO.swift in Sources */,
 				2AF069B02B518B3F00CA3E48 /* UICollectionViewRegisterable.swift in Sources */,
+				3CA32F532B81E200003DF637 /* MyPageAccountInfoViewModel.swift in Sources */,
 				2A0A730A2B541555004478C1 /* HttpMethod.swift in Sources */,
 				3CE9C12E2B4C08AE0086E4A3 /* WriteTextView.swift in Sources */,
 				2A8868D62B5069790017513A /* OnboardingEndingView.swift in Sources */,

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -89,6 +89,7 @@ enum StringLiterals {
         static let MyPageNavigationTitle = "마이"
         static let MyPageEditNavigationTitle = "프로필 편집"
         static let MyPageAccountInfoNavigationTitle = "계정 정보"
+        static let MyPageSignOutNavigationTitle = "계정 삭제"
         static let myPageEditIntroduction = "한줄 소개"
         static let myPageEditIntroductionPlease = "한 줄로 자신을 소개해주세요."
         static let myPageNoContentLabel = "님, 아직 글을 작성하지 않았네요!\n왠지 텅 빈 게시글이 허전하게 느껴져요."
@@ -101,7 +102,15 @@ enum StringLiterals {
         static let myPageUseTermURL = "https://joyous-ghost-8c7.notion.site/4ac9966cf7d944bf9595352edbc1b1b0"
         static let myPageMoreInfoTitle = "이용약관"
         static let myPageMoreInfoButtonTitle = "자세히 보기"
-        static let myPageSignOutButtonTitle = "회원탈퇴"
+        static let myPageSignOutButtonTitle = "계정삭제"
+        static let myPageLogoutPopupTitleLabel = "로그아웃"
+        static let myPageLogoutPopupContentLabel = "계정에서 로그아웃하시겠어요?"
+        static let myPageLogoutPopupLeftButtonTitle = "취소"
+        static let myPageLogoutPopupRightButtonTitle = "확인"
+        static let myPageSignOutPopupTitleLabel = "계정삭제"
+        static let myPageSignOutPopupContentLabel = "계정을 삭제하시겠어요?"
+        static let myPageSignOutPopupLeftButtonTitle = "취소"
+        static let myPageSignOutPopupRightButtonTitle = "확인"
     }
     
     enum TransparencyInfo {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBePopupView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/DontBePopupView.swift
@@ -44,7 +44,7 @@ final class DontBePopupView: UIView {
     
     private let popupContentLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .donBlack
+        label.textColor = .donGray11
         label.textAlignment = .center
         label.font = UIFont.font(.body4)
         label.numberOfLines = 0

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -223,7 +223,21 @@ extension MyPageAccountInfoViewController {
         output.isSignOutResult
             .sink { result in
                 if result == 200 {
-                    print("회원 탈퇴 완료")
+                    DispatchQueue.main.async {
+                        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                            DispatchQueue.main.async {
+                                let rootViewController = LoginViewController(viewModel: LoginViewModel(networkProvider: NetworkService()))
+                                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: rootViewController)
+                            }
+                        }
+                        
+                        saveUserData(UserInfo(isSocialLogined: false,
+                                              isFirstUser: false,
+                                              isJoinedApp: true,
+                                              isOnboardingFinished: true,
+                                              userNickname: loadUserData()?.userNickname ?? "",
+                                              memberId: loadUserData()?.memberId ?? 0))
+                    }
                 } else if result == 400 {
                     print("존재하지 않는 요청입니다.")
                 } else {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -18,7 +18,9 @@ final class MyPageAccountInfoViewController: UIViewController {
     let userTermURL = URL(string: StringLiterals.MyPage.myPageUseTermURL)
     
     private var cancelBag = CancelBag()
-    private let viewModel: MyPageViewModel
+    private let viewModel: MyPageAccountInfoViewModel
+    
+    private lazy var signOutButtonTapped = self.signOutPopupView.confirmButton.publisher(for: .touchUpInside).map { _ in }.eraseToAnyPublisher()
     
     var titleData = [
         "소셜 로그인",
@@ -29,7 +31,12 @@ final class MyPageAccountInfoViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private var signOutPopupView: DontBePopupView? = nil
+    private var signOutPopupView = DontBePopupView(
+        popupTitle: StringLiterals.MyPage.myPageSignOutPopupTitleLabel,
+        popupContent: StringLiterals.MyPage.myPageSignOutPopupContentLabel,
+        leftButtonTitle: StringLiterals.MyPage.myPageSignOutPopupLeftButtonTitle,
+        rightButtonTitle: StringLiterals.MyPage.myPageSignOutPopupRightButtonTitle
+    )
     
     private let topDivisionLine = UIView().makeDivisionLine()
     
@@ -75,7 +82,7 @@ final class MyPageAccountInfoViewController: UIViewController {
     
     // MARK: - Life Cycles
     
-    init(viewModel: MyPageViewModel) {
+    init(viewModel: MyPageAccountInfoViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -123,6 +130,8 @@ extension MyPageAccountInfoViewController {
         
         addUnderline(to: moreInfoButton)
         addUnderline(to: signOutButton)
+        
+        self.signOutPopupView.isHidden = true
     }
     
     private func setHierarchy() {
@@ -132,6 +141,10 @@ extension MyPageAccountInfoViewController {
                               moreInfoTitle,
                               moreInfoButton,
                               signOutButton)
+        
+        if let window = UIApplication.shared.keyWindowInConnectedScenes {
+            window.addSubviews(self.signOutPopupView)
+        }
     }
     
     private func setLayout() {
@@ -167,16 +180,21 @@ extension MyPageAccountInfoViewController {
             $0.top.equalTo(moreInfoButton.snp.bottom).offset(27.adjusted)
             $0.trailing.equalTo(moreInfoButton.snp.trailing)
         }
+        
+        self.signOutPopupView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
     
     private func setAddTarget() {
         moreInfoButton.addTarget(self, action: #selector(useTermButtonTapped), for: .touchUpInside)
-        signOutButton.addTarget(self, action: #selector(signOutButtonTapped), for: .touchUpInside)
+        signOutButton.addTarget(self, action: #selector(showSignOutPopup), for: .touchUpInside)
     }
     
     private func setDelegate() {
         self.accountInfoTableView.dataSource = self
         self.accountInfoTableView.delegate = self
+        self.signOutPopupView.delegate = self
     }
     
     private func setRegisterCell() {
@@ -189,14 +207,28 @@ extension MyPageAccountInfoViewController {
     
     private func bindViewModel() {
         let memberId = loadUserData()?.memberId ?? 0
-        let input = MyPageViewModel.Input(viewUpdate: Just((0, memberId )).eraseToAnyPublisher())
+        let input = MyPageAccountInfoViewModel.Input(
+            viewAppear: Just(()).eraseToAnyPublisher(),
+            signOutButtonTapped: signOutButtonTapped)
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
         
-        output.getData
+        output.getAccountInfoData
             .receive(on: RunLoop.main)
             .sink { _ in
                 self.accountInfoTableView.reloadData()
+            }
+            .store(in: self.cancelBag)
+        
+        output.isSignOutResult
+            .sink { result in
+                if result == 200 {
+                    print("회원 탈퇴 완료")
+                } else if result == 400 {
+                    print("존재하지 않는 요청입니다.")
+                } else {
+                    print("서버 내부에서 오류가 발생했습니다.")
+                }
             }
             .store(in: self.cancelBag)
     }
@@ -212,22 +244,7 @@ extension MyPageAccountInfoViewController {
     }
     
     func showSignOutPopupView() {
-        self.signOutPopupView = DontBePopupView(popupTitle: StringLiterals.MyPage.myPageSignOutPopupTitleLabel,
-                                                popupContent: StringLiterals.MyPage.myPageSignOutPopupContentLabel,
-                                                leftButtonTitle: StringLiterals.MyPage.myPageSignOutPopupLeftButtonTitle,
-                                                rightButtonTitle: StringLiterals.MyPage.myPageSignOutPopupRightButtonTitle)
-        
-        if let popupView = self.signOutPopupView {
-            if let window = UIApplication.shared.keyWindowInConnectedScenes {
-                window.addSubviews(popupView)
-            }
-            
-            popupView.delegate = self
-            
-            popupView.snp.makeConstraints {
-                $0.edges.equalToSuperview()
-            }
-        }
+        self.signOutPopupView.isHidden = false
     }
     
     @objc
@@ -245,7 +262,7 @@ extension MyPageAccountInfoViewController {
     }
     
     @objc
-    private func signOutButtonTapped() {
+    private func showSignOutPopup() {
         showSignOutPopupView()
         // 계정 삭제 사유 뷰로 이동(1차 앱 심사에서 보류)
 //        let signOutViewController = MyPageSignOutViewController()
@@ -279,11 +296,11 @@ extension MyPageAccountInfoViewController: UITableViewDataSource {
 
 extension MyPageAccountInfoViewController: DontBePopupDelegate {
     func cancleButtonTapped() {
-        self.signOutPopupView?.removeFromSuperview()
+        self.signOutPopupView.isHidden = true
     }
     
     func confirmButtonTapped() {
-        self.signOutPopupView?.removeFromSuperview()
+        self.signOutPopupView.isHidden = true
         print("계정삭제 완료")
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -29,6 +29,8 @@ final class MyPageAccountInfoViewController: UIViewController {
     
     // MARK: - UI Components
     
+    private var signOutPopupView: DontBePopupView? = nil
+    
     private let topDivisionLine = UIView().makeDivisionLine()
     
     private let accountInfoTableView: UITableView = {
@@ -85,7 +87,6 @@ final class MyPageAccountInfoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        getAPI()
         setUI()
         setHierarchy()
         setLayout()
@@ -209,7 +210,25 @@ extension MyPageAccountInfoViewController {
         let attributedString = NSAttributedString(string: button.currentTitle ?? "", attributes: attributes)
         button.setAttributedTitle(attributedString, for: .normal)
     }
-
+    
+    func showSignOutPopupView() {
+        self.signOutPopupView = DontBePopupView(popupTitle: StringLiterals.MyPage.myPageSignOutPopupTitleLabel,
+                                                popupContent: StringLiterals.MyPage.myPageSignOutPopupContentLabel,
+                                                leftButtonTitle: StringLiterals.MyPage.myPageSignOutPopupLeftButtonTitle,
+                                                rightButtonTitle: StringLiterals.MyPage.myPageSignOutPopupRightButtonTitle)
+        
+        if let popupView = self.signOutPopupView {
+            if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                window.addSubviews(popupView)
+            }
+            
+            popupView.delegate = self
+            
+            popupView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        }
+    }
     
     @objc
     private func backButtonTapped() {
@@ -227,7 +246,10 @@ extension MyPageAccountInfoViewController {
     
     @objc
     private func signOutButtonTapped() {
-        print("signOutButtonTapped")
+        showSignOutPopupView()
+        // 계정 삭제 사유 뷰로 이동(1차 앱 심사에서 보류)
+//        let signOutViewController = MyPageSignOutViewController()
+//        self.navigationController?.pushViewController(signOutViewController, animated: true)
     }
 }
 
@@ -255,22 +277,13 @@ extension MyPageAccountInfoViewController: UITableViewDataSource {
     }
 }
 
-// MARK: - Network
-
-extension MyPageAccountInfoViewController {
-    private func getAPI() {
-        
+extension MyPageAccountInfoViewController: DontBePopupDelegate {
+    func cancleButtonTapped() {
+        self.signOutPopupView?.removeFromSuperview()
+    }
+    
+    func confirmButtonTapped() {
+        self.signOutPopupView?.removeFromSuperview()
+        print("계정삭제 완료")
     }
 }
-
-//extension ExampleViewController: UICollectionViewDelegate {
-//
-//}
-//
-//extension ExampleViewController: UICollectionViewDataSource {
-//
-//}
-//
-//extension ExampleViewController: UICollectionViewFlowLayout {
-//
-//}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageSignOutViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageSignOutViewController.swift
@@ -1,0 +1,68 @@
+//
+//  MyPageSignOutViewController.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 2/12/24.
+//
+
+import UIKit
+
+class MyPageSignOutViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    private let myView = MyPageSignOutView()
+    private var navigationBackButton = BackButton()
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = myView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+
+extension MyPageSignOutViewController {
+    private func setUI() {
+        self.title = StringLiterals.MyPage.MyPageSignOutNavigationTitle
+        self.view.backgroundColor = .donWhite
+        
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
+        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
+        self.navigationItem.hidesBackButton = true
+        
+        let backButton = UIBarButtonItem.backButton(target: self, action: #selector(backButtonTapped))
+        self.navigationItem.leftBarButtonItem = backButton
+    }
+    
+    private func setHierarchy() {
+        
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    private func setDelegate() {
+        
+    }
+    
+    @objc
+    private func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -62,6 +62,7 @@ final class MyPageViewController: UIViewController {
     private var uploadToastView: DontBeToastView?
     private var deleteToastView: DontBeDeletePopupView?
     private var alreadyTransparencyToastView: DontBeToastView?
+    private var logoutPopupView: DontBePopupView? = nil
     
     let statusBarView = UIView(frame: UIApplication.shared.statusBarFrame)
     private var navigationBackButton: UIButton = {
@@ -295,6 +296,25 @@ extension MyPageViewController {
         }
     }
     
+    func showLogoutPopupView() {
+        self.logoutPopupView = DontBePopupView(popupTitle: StringLiterals.MyPage.myPageLogoutPopupTitleLabel,
+                                               popupContent: StringLiterals.MyPage.myPageLogoutPopupContentLabel,
+                                               leftButtonTitle: StringLiterals.MyPage.myPageLogoutPopupLeftButtonTitle,
+                                               rightButtonTitle: StringLiterals.MyPage.myPageLogoutPopupRightButtonTitle)
+        
+        if let popupView = self.logoutPopupView {
+            if let window = UIApplication.shared.keyWindowInConnectedScenes {
+                window.addSubviews(popupView)
+            }
+            
+            popupView.delegate = self
+            
+            popupView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        }
+    }
+    
     private func bindViewModel() {
         let input = MyPageViewModel.Input(viewUpdate: Just((1, self.memberId)).eraseToAnyPublisher())
         
@@ -417,8 +437,7 @@ extension MyPageViewController {
     
     @objc
     private func logoutButtonTapped() {
-        rootView.myPageBottomsheet.handleDismiss()
-        print("logoutButtonTapped")
+        showLogoutPopupView()
     }
     
     @objc
@@ -570,26 +589,36 @@ extension MyPageViewController: UICollectionViewDelegate {
 
 extension MyPageViewController: DontBePopupDelegate {
     func cancleButtonTapped() {
-        self.dismiss(animated: false)
+        if self.logoutPopupView != nil {
+            self.logoutPopupView?.removeFromSuperview()
+        } else {
+            self.dismiss(animated: false)
+        }
     }
     
     func confirmButtonTapped() {
-        self.dismiss(animated: false)
-        Task {
-            do {
-                if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
-                    let result = try await homeViewModel.postDownTransparency(accessToken: accessToken,
-                                                                               alarmTriggerType: self.alarmTriggerType,
-                                                                               targetMemberId: self.targetMemberId,
-                                                                               alarmTriggerId: self.alarmTriggerdId)
-                    self.bindViewModel()
-                    if result?.status == 400 {
-                        // 이미 투명도를 누른 대상인 경우, 토스트 메시지 보여주기
-                        showAlreadyTransparencyToast()
+        if self.logoutPopupView != nil {
+            self.logoutPopupView?.removeFromSuperview()
+            self.rootView.myPageBottomsheet.handleDismiss()
+            print("로그아웃 완료")
+        } else {
+            self.dismiss(animated: false)
+            Task {
+                do {
+                    if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
+                        let result = try await homeViewModel.postDownTransparency(accessToken: accessToken,
+                                                                                  alarmTriggerType: self.alarmTriggerType,
+                                                                                  targetMemberId: self.targetMemberId,
+                                                                                  alarmTriggerId: self.alarmTriggerdId)
+                        self.bindViewModel()
+                        if result?.status == 400 {
+                            // 이미 투명도를 누른 대상인 경우, 토스트 메시지 보여주기
+                            showAlreadyTransparencyToast()
+                        }
                     }
+                } catch {
+                    print(error)
                 }
-            } catch {
-                print(error)
             }
         }
     }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -600,7 +600,20 @@ extension MyPageViewController: DontBePopupDelegate {
         if self.logoutPopupView != nil {
             self.logoutPopupView?.removeFromSuperview()
             self.rootView.myPageBottomsheet.handleDismiss()
-            print("로그아웃 완료")
+            
+            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                DispatchQueue.main.async {
+                    let rootViewController = LoginViewController(viewModel: LoginViewModel(networkProvider: NetworkService()))
+                    sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: rootViewController)
+                }
+            }
+            
+            saveUserData(UserInfo(isSocialLogined: false,
+                                  isFirstUser: false,
+                                  isJoinedApp: true,
+                                  isOnboardingFinished: true,
+                                  userNickname: loadUserData()?.userNickname ?? "",
+                                  memberId: loadUserData()?.memberId ?? 0))
         } else {
             self.dismiss(animated: false)
             Task {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -421,7 +421,7 @@ extension MyPageViewController {
     @objc
     private func accountInfoButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
-        let vc = MyPageAccountInfoViewController(viewModel: self.viewModel)
+        let vc = MyPageAccountInfoViewController(viewModel: MyPageAccountInfoViewModel(networkProvider: NetworkService()))
         self.navigationController?.pushViewController(vc, animated: false)
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageAccountInfoViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageAccountInfoViewModel.swift
@@ -1,0 +1,106 @@
+//
+//  MyPageAccountInfoViewModel.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 2/18/24.
+//
+
+import Combine
+import Foundation
+
+final class MyPageAccountInfoViewModel: ViewModelType {
+    private let cancelBag = CancelBag()
+    private let networkProvider: NetworkServiceType
+    
+    private var getAccountInfoData = PassthroughSubject<Void, Never>()
+    private let isSignOutResult = PassthroughSubject<Int, Never>()
+    
+    var myPageMemberData: [String] = []
+    
+    struct Input {
+        let viewAppear: AnyPublisher<Void, Never>
+        let signOutButtonTapped: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let getAccountInfoData: PassthroughSubject<Void, Never>
+        let isSignOutResult: PassthroughSubject<Int, Never>
+    }
+    
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        input.viewAppear
+            .sink { _ in
+                Task {
+                    do {
+                        if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
+                            let result = try await self.getMyPageMemberDataAPI(accessToken: accessToken)
+                            if let data = result?.data {
+                                self.myPageMemberData = [data.socialPlatform, data.versionInformation, data.showMemberId ?? "money_rain_is_coming", data.joinDate]
+                                self.getAccountInfoData.send()
+                            }
+                        }
+                    } catch {
+                        print(error)
+                    }
+                }
+            }
+            .store(in: self.cancelBag)
+        
+        input.signOutButtonTapped
+            .sink { _ in
+                Task {
+                    do {
+                        if let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") {
+                            if let result = try await self.deleteMemberAPI(accessToken: accessToken) {
+                                self.isSignOutResult.send(result.status)
+                            }
+                        }
+                    } catch {
+                        print(error)
+                    }
+                }
+            }
+            .store(in: cancelBag)
+        
+        return Output(getAccountInfoData: getAccountInfoData,
+                      isSignOutResult: isSignOutResult)
+    }
+    
+    init(networkProvider: NetworkServiceType) {
+        self.networkProvider = networkProvider
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension MyPageAccountInfoViewModel {
+    private func getMyPageMemberDataAPI(accessToken: String) async throws -> BaseResponse<MyPageAccountInfoResponseDTO>? {
+        do {
+            let result: BaseResponse<MyPageAccountInfoResponseDTO>? = try await self.networkProvider.donNetwork(
+                type: .get,
+                baseURL: Config.baseURL + "/member-data",
+                accessToken: accessToken,
+                body: EmptyBody(),
+                pathVariables: ["":""])
+            return result
+        } catch {
+            return nil
+        }
+    }
+    
+    private func deleteMemberAPI(accessToken: String) async throws -> BaseResponse<[EmptyResponse]>? {
+        do {
+            let result: BaseResponse<[EmptyResponse]>? = try await self.networkProvider.donNetwork(
+                type: .delete,
+                baseURL: Config.baseURL + "/test-withdrawal",
+                accessToken: accessToken,
+                body: EmptyBody(),
+                pathVariables:["":""])
+            return result
+        } catch {
+            return nil
+        }
+    }
+}

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageSignOutView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageSignOutView.swift
@@ -1,0 +1,60 @@
+//
+//  MyPageSignOutView.swift
+//  DontBe-iOS
+//
+//  Created by 변상우 on 2/12/24.
+//
+
+import UIKit
+
+class MyPageSignOutView: UIView {
+
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setAddTarget()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+extension MyPageSignOutView {
+    private func setUI() {
+
+    }
+    
+    private func setHierarchy() {
+
+    }
+    
+    private func setLayout() {
+
+    }
+    
+    private func setAddTarget() {
+
+    }
+    
+    private func setRegisterCell() {
+        
+    }
+    
+    private func setDataBind() {
+        
+    }
+}


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 계정 삭제 API 앱 심사용 테스트 완료했고 구현 완료입니다~!

## 📟 관련 이슈
- Resolved: #144 
