### PR TITLE
Feat [#150] 프로필 사진 변경 API 연동 및 모든 프로필 사진 부분 적용

### DIFF
--- a/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
+++ b/DontBe-iOS/DontBe-iOS.xcodeproj/project.pbxproj
@@ -1491,10 +1491,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DontBe-iOS/Global/Resources/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Don't Be";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "게시글이나 프로필을 변경할 때 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1526,10 +1528,12 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "DontBe-iOS/Global/Resources/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Don't Be";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "게시글이나 프로필을 변경할 때 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/DontBe-iOS/DontBe-iOS/Application/AppDelegate.swift
+++ b/DontBe-iOS/DontBe-iOS/Application/AppDelegate.swift
@@ -36,7 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                   isJoinedApp: true,
                                   isOnboardingFinished: true,
                                   userNickname: loadUserData()?.userNickname ?? "",
-                                  memberId: loadUserData()?.memberId ?? 0))
+                                  memberId: loadUserData()?.memberId ?? 0,
+                                  userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
             // KeychainWrapper에 Access Token 저장하고 소셜로그인 화면으로
             let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") ?? ""
             KeychainWrapper.saveToken(accessToken, forKey: "accessToken")

--- a/DontBe-iOS/DontBe-iOS/Global/Extension/UIImageView+.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Extension/UIImageView+.swift
@@ -16,6 +16,7 @@ extension UIImageView {
                         DispatchQueue.main.async {
                             self?.image = image
                             self?.layer.cornerRadius = (self?.frame.size.width ?? 0) / 2.adjusted
+                            self?.contentMode = .scaleAspectFill
                             self?.clipsToBounds = true
                         }
                     }

--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -163,4 +163,8 @@ enum StringLiterals {
         static let warnUserGoogleFormURL = "https://forms.gle/FTgZKkajwtzFvAk99"
         static let errorMessage = "이런!\n현재 요청하신 페이지를 찾을 수 없어요!"
     }
+    
+    enum Camera {
+        static let photoNoAuth = "Don't Be 앱에 사진 권한이 없습니다.\n설정으로 이동하여 권한 설정을 해주세요."
+    }
 }

--- a/DontBe-iOS/DontBe-iOS/Global/Resources/Info.plist
+++ b/DontBe-iOS/DontBe-iOS/Global/Resources/Info.plist
@@ -2,20 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaolink</string>
-		<string>kakaokompassauth</string>
-	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -27,8 +15,18 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaolink</string>
+		<string>kakaokompassauth</string>
+	</array>
 	<key>NATIVE_APP_KEY</key>
 	<string>$(NATIVE_APP_KEY)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Regular.otf</string>

--- a/DontBe-iOS/DontBe-iOS/Network/UserProfile/DTO/RequestDTO/UserProfileRequestDTO.swift
+++ b/DontBe-iOS/DontBe-iOS/Network/UserProfile/DTO/RequestDTO/UserProfileRequestDTO.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - UserProfileRequestDTO
 
@@ -14,4 +15,11 @@ struct UserProfileRequestDTO: Encodable {
     let is_alarm_allowed: Bool
     let member_intro: String
     let profile_url: String
+}
+
+struct EditUserProfileRequestDTO {
+    let nickname: String
+    let is_alarm_allowed: Bool
+    let member_intro: String
+    let profile_image: UIImage
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Helpers/UserInfo.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Helpers/UserInfo.swift
@@ -14,6 +14,7 @@ struct UserInfo: Codable {
     let isOnboardingFinished: Bool
     let userNickname: String
     let memberId: Int
+    let userProfileImage: String
 }
 
 // 구조체를 UserDefault에 저장하는 함수

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/Cells/HomeCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/Cells/HomeCollectionViewCell.swift
@@ -45,7 +45,6 @@ final class HomeCollectionViewCell: UICollectionViewCell, UICollectionViewRegist
         image.clipsToBounds = true
         image.layer.borderWidth = 1.adjusted
         image.layer.borderColor = UIColor.clear.cgColor
-        image.image = ImageLiterals.Common.imgProfile
         image.layer.cornerRadius = 22.adjusted
         image.isUserInteractionEnabled = true
         return image

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/Cells/HomeCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/Cells/HomeCollectionViewCell.swift
@@ -11,6 +11,12 @@ import SnapKit
 
 final class HomeCollectionViewCell: UICollectionViewCell, UICollectionViewRegisterable {
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        profileImageView.image = ImageLiterals.Common.imgProfile
+    }
+    
     // MARK: - Properties
     
     var KebabButtonAction: (() -> Void) = {}

--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -70,7 +70,6 @@ final class HomeViewController: UIViewController {
         setLayout()
         setDelegate()
         setAddTarget()
-        bindViewModel()
         setRefreshControl()
     }
     
@@ -215,7 +214,6 @@ extension HomeViewController {
         DispatchQueue.main.async {
             self.bindViewModel()
         }
-        self.homeCollectionView.reloadData()
         self.perform(#selector(self.finishedRefreshing), with: nil, afterDelay: 0.1)
     }
     
@@ -440,14 +438,13 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
             self.present(self.transparentPopupVC, animated: false, completion: nil)
         }
         
-        cell.profileImageView.load(url: homeViewModel.postData[indexPath.row].memberProfileUrl)
         cell.nicknameLabel.text = homeViewModel.postData[indexPath.row].memberNickname
         cell.transparentLabel.text = "투명도 \(homeViewModel.postData[indexPath.row].memberGhost)%"
         cell.contentTextLabel.text = homeViewModel.postData[indexPath.row].contentText
         cell.likeNumLabel.text = "\(homeViewModel.postData[indexPath.row].likedNumber)"
         cell.commentNumLabel.text = "\(homeViewModel.postData[indexPath.row].commentNumber)"
         cell.timeLabel.text = "\(homeViewModel.postData[indexPath.row].time.formattedTime())"
-        cell.profileImageView.load(url: "\(homeViewModel.postData[indexPath.row].memberProfileUrl)")
+        cell.profileImageView.load(url: "\(self.homeViewModel.postData[indexPath.row].memberProfileUrl)")
         cell.likeButton.setImage(homeViewModel.postData[indexPath.row].isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
         cell.isLiked = self.homeViewModel.postData[indexPath.row].isLiked
         cell.likeButton.setImage(cell.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinProfileViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import Photos
+import PhotosUI
 
 import SnapKit
 
@@ -21,8 +23,12 @@ final class JoinProfileViewController: UIViewController {
         return self.originView.nickNameTextField.text ?? ""
     }.eraseToAnyPublisher()
     private lazy var finishButtonTapped = self.originView.finishActiveButton.publisher(for: .touchUpInside).map { _ in
-        return self.originView.nickNameTextField.text ?? ""
+        return EditUserProfileRequestDTO(nickname: self.originView.nickNameTextField.text ?? "",
+                                         is_alarm_allowed: true,
+                                         member_intro: "",
+                                         profile_image: self.originView.profileImage.image ?? ImageLiterals.Common.imgProfile)
     }.eraseToAnyPublisher()
+    
     
     // MARK: - UI Components
     
@@ -56,6 +62,7 @@ final class JoinProfileViewController: UIViewController {
         setUI()
         setHierarchy()
         setLayout()
+        setAddTarget()
         bindViewModel()
     }
     
@@ -91,6 +98,10 @@ extension JoinProfileViewController {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().inset(23.adjusted)
         }
+    }
+    
+    private func setAddTarget() {
+        self.originView.plusButton.addTarget(self, action: #selector(plusButtonTapped), for: .touchUpInside)
     }
     
     private func setDelegate() {
@@ -137,5 +148,75 @@ extension JoinProfileViewController {
         self.originView.finishButton.isHidden = false
         self.originView.duplicationCheckDescription.text = StringLiterals.Join.duplicationCheckDescription
         self.originView.duplicationCheckDescription.textColor = .donGray8
+    }
+    
+    @objc
+    private func plusButtonTapped() {
+        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+        
+        switch status {
+        case .authorized, .limited:
+            presentPicker()
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .addOnly) { [weak self] status in
+                DispatchQueue.main.async {
+                    if status == .authorized {
+                        self?.presentPicker()
+                    }
+                }
+            }
+        case .denied, .restricted:
+            authSettingOpen()
+        default:
+            break
+        }
+    }
+    
+    private func presentPicker() {
+        var configuration = PHPickerConfiguration()
+        configuration.filter = .images // 이미지만 필터링
+        configuration.selectionLimit = 1 // 선택 제한
+        
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+    
+    func authSettingOpen() {
+        let message = "Don't Be 앱에 사진 권한이 없습니다.\n설정으로 이동하여 권한 설정을 해주세요."
+        
+        let alert = UIAlertController(title: "설정", message: message, preferredStyle: .alert)
+        
+        let cancle = UIAlertAction(title: "닫기", style: .default)
+        
+        let confirm = UIAlertAction(title: "권한설정하기", style: .default) { (UIAlertAction) in
+            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+        }
+        
+        alert.addAction(cancle)
+        alert.addAction(confirm)
+        
+        self.present(alert, animated: true, completion: nil)
+    }
+}
+
+extension JoinProfileViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        dismiss(animated: true)
+        
+        guard let selectedImage = results.first else { return }
+        
+        selectedImage.itemProvider.loadObject(ofClass: UIImage.self) { (image, error) in
+            DispatchQueue.main.async {
+                if let image = image as? UIImage {
+                    self.originView.profileImage.image = image
+                    self.originView.profileImage.contentMode = .scaleAspectFill
+                    self.originView.profileImage.layer.cornerRadius = self.originView.profileImage.frame.size.width / 2
+                    self.originView.profileImage.clipsToBounds = true
+                } else if let error = error {
+                    print(error)
+                }
+            }
+        }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewControllers/JoinProfileViewController.swift
@@ -183,7 +183,7 @@ extension JoinProfileViewController {
     }
     
     func authSettingOpen() {
-        let message = "Don't Be 앱에 사진 권한이 없습니다.\n설정으로 이동하여 권한 설정을 해주세요."
+        let message = StringLiterals.Camera.photoNoAuth
         
         let alert = UIAlertController(title: "설정", message: message, preferredStyle: .alert)
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
@@ -78,7 +78,8 @@ final class JoinProfileViewModel: ViewModelType {
                                       isJoinedApp: true,
                                       isOnboardingFinished: false,
                                       userNickname: value,
-                                      memberId: loadUserData()?.memberId ?? 0))
+                                      memberId: loadUserData()?.memberId ?? 0,
+                                      userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
             }
             .store(in: self.cancelBag)
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/ViewModels/JoinProfileViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import UIKit
 
 final class JoinProfileViewModel: ViewModelType {
     
@@ -27,7 +28,7 @@ final class JoinProfileViewModel: ViewModelType {
     struct Input {
         let backButtonTapped: AnyPublisher<Void, Never>
         let duplicationCheckButtonTapped: AnyPublisher<String, Never>
-        let finishButtonTapped: AnyPublisher<String, Never>
+        let finishButtonTapped: AnyPublisher<EditUserProfileRequestDTO, Never>
     }
     
     struct Output {
@@ -64,20 +65,18 @@ final class JoinProfileViewModel: ViewModelType {
             .sink { value in
                 // 회원가입 서버통신
                 Task {
-                    do {
-                        let statusCode = try await self.patchUserInfoAPI(nickname: value)?.status
-                        if statusCode == 200 {
-                            self.pushOrPopViewController.send(1)
-                        }
-                    } catch {
-                        print(error)
-                    }
+                    self.patchUserInfoDataAPI(nickname: value.nickname,
+                                              isAlarmAllowed: value.is_alarm_allowed,
+                                              memberIntro: value.member_intro,
+                                              profileImage: value.profile_image)
+                    
+                    self.pushOrPopViewController.send(1)
                 }
                 saveUserData(UserInfo(isSocialLogined: true,
                                       isFirstUser: true,
                                       isJoinedApp: true,
                                       isOnboardingFinished: false,
-                                      userNickname: value,
+                                      userNickname: value.nickname,
                                       memberId: loadUserData()?.memberId ?? 0,
                                       userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
             }
@@ -124,6 +123,67 @@ extension JoinProfileViewModel {
         } catch {
             return nil
         }
+    }
+    
+    func patchUserInfoDataAPI(nickname: String, isAlarmAllowed: Bool, memberIntro: String, profileImage: UIImage) {
+        guard let url = URL(string: Config.baseURL + "/user-profile2") else { return }
+        guard let accessToken = KeychainWrapper.loadToken(forKey: "accessToken") else { return }
+        
+        let imageData = profileImage.jpegData(compressionQuality: 0.5)!
+        
+        let parameters: [String: Any] = [
+            "nickname": nickname,
+            "isAlarmAllowed": isAlarmAllowed,
+            "memberIntro": memberIntro
+        ]
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        
+        // Multipart form data 생성
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        var requestBodyData = Data()
+        
+        // 프로필 정보 추가
+        requestBodyData.append("--\(boundary)\r\n".data(using: .utf8)!)
+        requestBodyData.append("Content-Disposition: form-data; name=\"info\"\r\n\r\n".data(using: .utf8)!)
+        requestBodyData.append(try! JSONSerialization.data(withJSONObject: parameters, options: []))
+        requestBodyData.append("\r\n".data(using: .utf8)!)
+        
+        // 프로필 이미지 데이터 추가
+        requestBodyData.append("--\(boundary)\r\n".data(using: .utf8)!)
+        requestBodyData.append("Content-Disposition: form-data; name=\"file\"; filename=\"dontbe.jpeg\"\r\n".data(using: .utf8)!)
+        requestBodyData.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        requestBodyData.append(imageData)
+        requestBodyData.append("\r\n".data(using: .utf8)!)
+        
+        requestBodyData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        
+        // HTTP body에 데이터 설정
+        request.httpBody = requestBodyData
+        
+        // URLSession으로 요청 보내기
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let error = error {
+                print("Error:", error)
+                return
+            }
+            
+            // 응답 처리
+            if let response = response as? HTTPURLResponse {
+                print(response)
+                print("Response status code:", response.statusCode)
+            }
+            
+            if let data = data {
+                // 서버 응답 데이터 처리
+                print("Response data:", String(data: data, encoding: .utf8) ?? "Empty response")
+            }
+        }
+        task.resume()
     }
 }
 

--- a/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinProfileView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Join/Views/JoinProfileView.swift
@@ -18,15 +18,17 @@ final class JoinProfileView: UIView {
     let profileImage: UIImageView = {
         let profileImage = UIImageView()
         profileImage.image = ImageLiterals.Common.imgProfile
+        profileImage.contentMode = .scaleAspectFill
+        profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
+        profileImage.clipsToBounds = true
         return profileImage
     }()
     
-    // 2차 스프린트
-    //    let plusButton: UIButton = {
-    //        let plusButton = UIButton()
-    //        plusButton.setImage(ImageLiterals.Join.btnPlus, for: .normal)
-    //        return plusButton
-    //    }()
+    let plusButton: UIButton = {
+        let plusButton = UIButton()
+        plusButton.setImage(ImageLiterals.Join.btnPlus, for: .normal)
+        return plusButton
+    }()
     
     private let nickNameLabel: UILabel = {
         let nickNameLabel = UILabel()
@@ -121,7 +123,7 @@ extension JoinProfileView {
     private func setHierarchy() {
         self.addSubviews(topDivisionLine,
                          profileImage,
-                         //                         plusButton,
+                         plusButton,
                          nickNameLabel,
                          nickNameTextField,
                          duplicationCheckButton,
@@ -146,11 +148,11 @@ extension JoinProfileView {
             $0.size.equalTo(100.adjusted)
         }
         
-        //        plusButton.snp.makeConstraints {
-        //            $0.top.equalTo(profileImage).offset(72.adjusted)
-        //            $0.leading.equalTo(profileImage).offset(78.adjusted)
-        //            $0.size.equalTo(34.adjusted)
-        //        }
+        plusButton.snp.makeConstraints {
+            $0.top.equalTo(profileImage).offset(71.adjusted)
+            $0.leading.equalTo(profileImage).offset(75.adjusted)
+            $0.size.equalTo(34.adjusted)
+        }
         
         nickNameLabel.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).inset(171.adjustedH)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -126,7 +126,8 @@ extension LoginViewModel {
                                       isJoinedApp: false,
                                       isOnboardingFinished: false,
                                       userNickname: userNickname,
-                                      memberId: memberId))
+                                      memberId: memberId,
+                                      userProfileImage: StringLiterals.Network.baseImageURL))
                 
                 // KeychainWrapper에 Access Token 저장
                 let accessToken = data?.data?.accessToken ?? ""

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -236,7 +236,8 @@ extension MyPageAccountInfoViewController {
                                               isJoinedApp: true,
                                               isOnboardingFinished: true,
                                               userNickname: loadUserData()?.userNickname ?? "",
-                                              memberId: loadUserData()?.memberId ?? 0))
+                                              memberId: loadUserData()?.memberId ?? 0,
+                                              userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
                     }
                 } else if result == 400 {
                     print("존재하지 않는 요청입니다.")

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageCommentViewController.swift
@@ -306,7 +306,6 @@ extension MyPageCommentViewController: UICollectionViewDataSource, UICollectionV
             $0.top.equalTo(cell.contentTextLabel.snp.bottom).offset(4.adjusted)
             $0.height.equalTo(cell.commentStackView)
             $0.trailing.equalTo(cell.kebabButton).inset(8.adjusted)
-            $0.bottom.equalToSuperview().inset(16)
         }
         
         cell.commentStackView.isHidden = true

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -75,12 +75,13 @@ final class MyPageEditProfileViewController: UIViewController {
         let backButton = UIBarButtonItem.backButton(target: self, action: #selector(navBackButtonTapped))
         self.navigationItem.leftBarButtonItem = backButton
         
+        self.nicknameEditView.nickNameTextField.text = nickname
+        self.nicknameEditView.numOfLetters.text = "(\(nickname.count)/12)"
+        
         if introText == "" {
             self.introductionEditView.contentTextView.addPlaceholder(StringLiterals.MyPage.myPageEditIntroductionPlease, padding: UIEdgeInsets(top: 14.adjusted, left: 14.adjusted, bottom: 14.adjusted, right: 14.adjusted))
         } else {
-            self.nicknameEditView.nickNameTextField.text = nickname
             self.introductionEditView.contentTextView.text = introText
-            self.nicknameEditView.numOfLetters.text = "(\(nickname.count)/12)"
             self.introductionEditView.numOfLetters.text = "(\(introText.count)/50"
         }
         setDelegate()

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -124,7 +124,6 @@ extension MyPageEditProfileViewController {
         introductionEditView.snp.makeConstraints {
             $0.top.equalTo(nicknameEditView.duplicationCheckDescription.snp.bottom).offset(16.adjustedH)
             $0.leading.trailing.bottom.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -231,7 +231,7 @@ extension MyPageEditProfileViewController {
     }
     
     func authSettingOpen() {
-        let message = "Don't Be 앱에 사진 권한이 없습니다.\n설정으로 이동하여 권한 설정을 해주세요."
+        let message = StringLiterals.Camera.photoNoAuth
         
         let alert = UIAlertController(title: "설정", message: message, preferredStyle: .alert)
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -108,6 +108,10 @@ final class MyPageViewController: UIViewController {
         bindViewModel()
         setNotification()
         
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.refreshData()
+        }
+        
         let image = ImageLiterals.MyPage.icnMenu
         let renderedImage = image.withRenderingMode(.alwaysOriginal)
         
@@ -413,6 +417,7 @@ extension MyPageViewController {
     private func profileEditButtonTapped() {
         rootView.myPageBottomsheet.handleDismiss()
         let vc = MyPageEditProfileViewController(viewModel: MyPageProfileViewModel(networkProvider: NetworkService()))
+        vc.memberId = self.memberId
         vc.nickname = self.rootView.myPageProfileView.userNickname.text ?? ""
         vc.introText = self.rootView.myPageProfileView.userIntroduction.text ?? ""
         self.navigationController?.pushViewController(vc, animated: false)

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -374,6 +374,14 @@ extension MyPageViewController {
         } else {
             self.rootView.myPageContentViewController.noContentLabel.text = "\(data.nickname)" + StringLiterals.MyPage.myPageNoContentLabel
             self.rootView.myPageCommentViewController.noCommentLabel.text = StringLiterals.MyPage.myPageNoCommentLabel
+            
+            saveUserData(UserInfo(isSocialLogined: true,
+                                  isFirstUser: false,
+                                  isJoinedApp: true,
+                                  isOnboardingFinished: true,
+                                  userNickname: data.nickname,
+                                  memberId: loadUserData()?.memberId ?? 0,
+                                  userProfileImage: data.memberProfileUrl))
         }
     }
     
@@ -618,7 +626,8 @@ extension MyPageViewController: DontBePopupDelegate {
                                   isJoinedApp: true,
                                   isOnboardingFinished: true,
                                   userNickname: loadUserData()?.userNickname ?? "",
-                                  memberId: loadUserData()?.memberId ?? 0))
+                                  memberId: loadUserData()?.memberId ?? 0,
+                                  userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
         } else {
             self.dismiss(animated: false)
             Task {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageProfileViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewModels/MyPageProfileViewModel.swift
@@ -95,7 +95,8 @@ final class MyPageProfileViewModel: ViewModelType {
                                       isJoinedApp: true,
                                       isOnboardingFinished: true,
                                       userNickname: value.nickname,
-                                      memberId: loadUserData()?.memberId ?? 0))
+                                      memberId: loadUserData()?.memberId ?? 0,
+                                      userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
                 
                 self.popViewController.send()
             }

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
@@ -22,15 +22,16 @@ final class MyPageNicknameEditView: UIView {
     let profileImage: UIImageView = {
         let profileImage = UIImageView()
         profileImage.load(url: StringLiterals.Network.baseImageURL)
+        profileImage.contentMode = .scaleAspectFill
+        profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
         return profileImage
     }()
     
-    // 2차 스프린트
-//    let plusButton: UIButton = {
-//        let plusButton = UIButton()
-//        plusButton.setImage(ImageLiterals.Join.btnPlus, for: .normal)
-//        return plusButton
-//    }()
+    let plusButton: UIButton = {
+        let plusButton = UIButton()
+        plusButton.setImage(ImageLiterals.Join.btnPlus, for: .normal)
+        return plusButton
+    }()
     
     private let nickNameLabel: UILabel = {
         let nickNameLabel = UILabel()
@@ -112,7 +113,7 @@ extension MyPageNicknameEditView {
     func setHierarchy() {
         self.addSubviews(topDivisionLine,
                          profileImage,
-//                         plusButton,
+                         plusButton,
                          nickNameLabel,
                          nickNameTextField,
                          duplicationCheckButton,
@@ -135,11 +136,11 @@ extension MyPageNicknameEditView {
             $0.size.equalTo(100.adjusted)
         }
         
-//        plusButton.snp.makeConstraints {
-//            $0.top.equalTo(profileImage).offset(72.adjusted)
-//            $0.leading.equalTo(profileImage).offset(78.adjusted)
-//            $0.size.equalTo(34.adjusted)
-//        }
+        plusButton.snp.makeConstraints {
+            $0.top.equalTo(profileImage).offset(71.adjusted)
+            $0.leading.equalTo(profileImage).offset(75.adjusted)
+            $0.size.equalTo(34.adjusted)
+        }
         
         nickNameLabel.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).inset(171.adjustedH)

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageNicknameEditView.swift
@@ -21,7 +21,7 @@ final class MyPageNicknameEditView: UIView {
 
     let profileImage: UIImageView = {
         let profileImage = UIImageView()
-        profileImage.load(url: StringLiterals.Network.baseImageURL)
+        profileImage.image = ImageLiterals.Common.imgProfile
         profileImage.contentMode = .scaleAspectFill
         profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
         return profileImage

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageProfileView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/Views/MyPageProfileView.swift
@@ -29,7 +29,9 @@ final class MyPageProfileView: UIView {
     
     let profileImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.load(url: StringLiterals.Network.baseImageURL)
+        imageView.image = ImageLiterals.Common.imgProfile
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = imageView.frame.size.width / 2
         return imageView
     }()
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Notification/Cells/NotificationTableViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Notification/Cells/NotificationTableViewCell.swift
@@ -15,7 +15,8 @@ final class NotificationTableViewCell: UITableViewCell, UITableViewCellRegistera
     
     private let profileImage: UIImageView = {
         let profileImage = UIImageView()
-        profileImage.contentMode = .scaleAspectFit
+        profileImage.contentMode = .scaleAspectFill
+        profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
         return profileImage
     }()
     
@@ -92,7 +93,7 @@ extension NotificationTableViewCell {
         profileImage.load(url: list.triggerMemberProfileUrl)
         profileImage.snp.remakeConstraints {
             $0.centerY.equalToSuperview()
-            $0.top.leading.equalToSuperview().inset(14.adjusted)
+            $0.leading.equalToSuperview().inset(14.adjusted)
             $0.size.equalTo(42.adjusted)
         }
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewControllers/OnboardingEndingViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewControllers/OnboardingEndingViewController.swift
@@ -74,11 +74,19 @@ extension OnboardingEndingViewController {
     
     private func bindViewModel() {
         let input = OnboardingEndingViewModel.Input(
+            viewWillAppear: Just((loadUserData()?.memberId ?? 0)).eraseToAnyPublisher(),
             backButtonTapped: backButtonTapped,
             startButtonTapped: startButtonTapped,
             skipButtonTapped: skipButtonTapped)
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.getProfileData
+            .receive(on: RunLoop.main)
+            .sink { data in
+                self.originView.profileImage.load(url: data.memberProfileUrl)
+            }
+            .store(in: self.cancelBag)
         
         output.voidPublisher
             .receive(on: RunLoop.main)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewModels/OnboardingEndingViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/ViewModels/OnboardingEndingViewModel.swift
@@ -62,7 +62,8 @@ final class OnboardingEndingViewModel: ViewModelType {
                                       isJoinedApp: true,
                                       isOnboardingFinished: true,
                                       userNickname: loadUserData()?.userNickname ?? "",
-                                      memberId: loadUserData()?.memberId ?? 0))
+                                      memberId: loadUserData()?.memberId ?? 0,
+                                      userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
             }
             .store(in: self.cancelBag)
         
@@ -76,7 +77,8 @@ final class OnboardingEndingViewModel: ViewModelType {
                                       isJoinedApp: true,
                                       isOnboardingFinished: true,
                                       userNickname: loadUserData()?.userNickname ?? "",
-                                      memberId: loadUserData()?.memberId ?? 0))
+                                      memberId: loadUserData()?.memberId ?? 0,
+                                      userProfileImage: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL))
             }
             .store(in: self.cancelBag)
         

--- a/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/Views/OnboardingEndingView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Onboarding/Views/OnboardingEndingView.swift
@@ -25,9 +25,10 @@ final class OnboardingEndingView: UIView {
         return title
     }()
     
-    private let profileImage: UIImageView = {
+    let profileImage: UIImageView = {
         let profile = UIImageView()
-        profile.image = ImageLiterals.Common.imgProfile
+        profile.contentMode = .scaleAspectFill
+        profile.layer.cornerRadius = profile.frame.width / 2
         return profile
     }()
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
@@ -44,7 +44,6 @@ final class PostReplyCollectionViewCell: UICollectionViewCell, UICollectionViewR
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
-        image.image = ImageLiterals.Common.imgProfile
         image.layer.cornerRadius = 22.adjusted
         image.isUserInteractionEnabled = true
         return image

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostDetailViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostDetailViewController.swift
@@ -73,10 +73,6 @@ final class PostDetailViewController: UIViewController {
         setTextFieldGesture()
         setRefreshControll()
         setLayout()
-        refreshPostDidDrag()
-        // setNotification()
-        getAPI()
-        refreshControl.beginRefreshing()
     }
     
     init(viewModel: PostDetailViewModel) {
@@ -107,6 +103,7 @@ final class PostDetailViewController: UIViewController {
             $0.height.equalTo(56.adjusted)
         }
         
+        getAPI()
         setAppearNotification()
     }
     
@@ -176,7 +173,6 @@ extension PostDetailViewController {
     @objc func didDismissDetailNotification(_ notification: Notification) {
         DispatchQueue.main.async {
             self.getAPI()
-            self.postReplyCollectionView.reloadData()
         }
     }
     
@@ -710,6 +706,7 @@ extension PostDetailViewController: UICollectionViewDataSource, UICollectionView
             header.isLiked = self.postView.isLiked
             header.likeButton.setImage(header.isLiked ? ImageLiterals.Posting.btnFavoriteActive : ImageLiterals.Posting.btnFavoriteInActive, for: .normal)
             header.ghostButton.addTarget(self, action: #selector(transparentShowPopupButton), for: .touchUpInside)
+            header.profileImageView.image = self.postView.profileImageView.image
             
             DispatchQueue.main.async {
                 self.postViewHeight = Int(header.PostbackgroundUIView.frame.height)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostDetailViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/PostDetailViewController.swift
@@ -500,6 +500,7 @@ extension PostDetailViewController {
         viewController.contentId = self.contentId
         viewController.userNickname = self.userNickName
         viewController.userContent = self.contentText
+        viewController.userProfileImage = self.postView.profileImageView.image ?? ImageLiterals.Common.imgProfile
         present(navigationController, animated: true, completion: nil)
     }
     
@@ -553,8 +554,7 @@ extension PostDetailViewController {
         
         self.collectionHeaderView?.profileImageView.load(url: data.memberProfileUrl)
         self.textFieldView.replyTextFieldLabel.text = "\(data.memberNickname)" + StringLiterals.Post.textFieldLabel
-        self.postView
-            .postNicknameLabel.text = data.memberNickname
+        self.postView.postNicknameLabel.text = data.memberNickname
         self.postUserNickname = "\(data.memberNickname)"
         self.userNickName = "\(data.memberNickname)"
         self.postView.contentTextLabel.text = data.contentText

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/ViewControllers/WriteReplyViewController.swift
@@ -24,6 +24,7 @@ final class WriteReplyViewController: UIViewController {
     var contentId: Int = 0
     var tabBarHeight: CGFloat = 0
     var userNickname: String = ""
+    var userProfileImage: UIImage = ImageLiterals.Common.imgProfile
     var userContent: String = ""
     
     // MARK: - UI Components
@@ -54,9 +55,6 @@ final class WriteReplyViewController: UIViewController {
         setUI()
         setBottomSheet()
         setNavigationBarButtonItem()
-        
-        writeView.writeReplyPostview.postNicknameLabel.text = self.userNickname
-        writeView.writeReplyPostview.contentTextLabel.text = self.userContent
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -85,6 +83,10 @@ extension WriteReplyViewController {
         writeView.backgroundColor = .donWhite
         title = "답글달기"
         cancelReplyPopupVC.modalPresentationStyle = .overFullScreen
+        
+        writeView.writeReplyPostview.postNicknameLabel.text = self.userNickname
+        writeView.writeReplyPostview.contentTextLabel.text = self.userContent
+        writeView.writeReplyPostview.profileImageView.image = self.userProfileImage
     }
     
     private func sendData() {

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostDetailCollectionHeaderView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostDetailCollectionHeaderView.swift
@@ -45,7 +45,6 @@ final class PostDetailCollectionHeaderView: UICollectionReusableView {
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
         image.layer.cornerRadius = 22.adjusted
-        image.image = ImageLiterals.Common.imgProfile
         image.isUserInteractionEnabled = true
         return image
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
@@ -29,8 +29,7 @@ final class PostReplyTextFieldView: UIView {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
-        image.image = ImageLiterals.Common.imgProfile
-        image.backgroundColor = .lightGray
+        image.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
         image.layer.cornerRadius = 20.adjusted
         return image
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyContentView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyContentView.swift
@@ -22,12 +22,11 @@ final class WriteReplyContentView: UIView {
         return view
     }()
     
-    private let profileImageView: UIImageView = {
+    let profileImageView: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
+        image.layer.cornerRadius = image.frame.size.width / 2.adjusted
         image.clipsToBounds = true
-        image.layer.cornerRadius = 22.adjusted
-        image.image = ImageLiterals.Common.imgProfile
         return image
     }()
     

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
@@ -22,7 +22,7 @@ final class WriteReplyEditorView: UIView {
     
     private let userProfileImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.load(url: StringLiterals.Network.baseImageURL)
+        imageView.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
@@ -98,6 +98,7 @@ extension WriteViewController {
         navigationItem.leftBarButtonItem = backButton
         
         self.rootView.writeTextView.userNickname.text = loadUserData()?.userNickname
+        self.rootView.writeTextView.userProfileImage.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
         
         if let window = UIApplication.shared.keyWindowInConnectedScenes {
             window.addSubview(banView)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -20,7 +20,8 @@ final class WriteTextView: UIView {
     
     let userProfileImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.load(url: StringLiterals.Network.baseImageURL)
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = imageView.frame.size.width / 2
         return imageView
     }()
     


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 프로필 이미지 변경 API 연동 및 구현 완료했습니다!
- 모든 뷰에서 프로필 이미지 부분을 서버에서 불러오는 이미지로 변경했습니다.
- 모든 뷰 프로필 이미지를 동그랗게 수정했습니다.
- 회원가입 시, 이미지 변경 가능하도록 수정했습니다.

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- UserInfo 에 userProfileImage 값이 하나 더 추가되어서 자신의 프로필 이미지를 사용할 때, 사용하시면 편합니다!
- loadUserData()?.userProfileImage ~ 와 같이 아래처럼 사용하면 됩니다!

```swift
let profileImageView: UIImageView = {
    let image = UIImageView()
    image.contentMode = .scaleAspectFill
    image.clipsToBounds = true
    image.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
    image.layer.cornerRadius = 20.adjusted
    return image
}()
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|회원가입|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/c59c43d9-1236-4265-85e9-c3c20f253194" width ="250">|
|마이페이지|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/563b20fe-1811-4094-9407-69911bc40176" width ="250">|
|접근 권한|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/59056821/0771c4fb-aa56-43d7-a4e3-4d2c0cdda93e" width ="250">|

## 📟 관련 이슈
- Resolved: #150 
