### PR TITLE
Fix [#157] 릴리즈 QA 수정사항 1차 반영

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
+++ b/DontBe-iOS/DontBe-iOS/Global/Literals/StringLiterals.swift
@@ -49,7 +49,7 @@ enum StringLiterals {
     
     enum Onboarding {
         static let placeHolder = "한 문장으로 소개를 남겨주세요!"
-        static let information = "설정한 닉네임, 한 줄 소개는 설정에서 변경 가능해요!\n작성한 한 줄 소개는 작성한 게시글로 업로드 돼요."
+        static let information = "설정한 닉네임, 한 줄 소개는 설정에서 변경 가능해요!\n작성한 한 줄 소개는 게시글로 업로드 돼요."
     }
     
     enum Button {

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageAccountInfoViewController.swift
@@ -242,7 +242,7 @@ extension MyPageAccountInfoViewController {
     
     @objc
     private func backButtonTapped() {
-        self.navigationController?.popViewController(animated: true)
+        self.navigationController?.popViewController(animated: false)
     }
     
     @objc

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -160,7 +160,7 @@ extension MyPageEditProfileViewController {
         output.popViewController
             .receive(on: RunLoop.main)
             .sink { _ in
-                self.navigationController?.popViewController(animated: true)
+                self.navigationController?.popViewController(animated: false)
             }
             .store(in: self.cancelBag)
         
@@ -205,7 +205,7 @@ extension MyPageEditProfileViewController {
     
     @objc
     private func navBackButtonTapped() {
-        self.navigationController?.popViewController(animated: true)
+        self.navigationController?.popViewController(animated: false)
     }
     
     @objc

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageEditProfileViewController.swift
@@ -87,7 +87,7 @@ final class MyPageEditProfileViewController: UIViewController {
             self.introductionEditView.contentTextView.addPlaceholder(StringLiterals.MyPage.myPageEditIntroductionPlease, padding: UIEdgeInsets(top: 14.adjusted, left: 14.adjusted, bottom: 14.adjusted, right: 14.adjusted))
         } else {
             self.introductionEditView.contentTextView.text = introText
-            self.introductionEditView.numOfLetters.text = "(\(introText.count)/50"
+            self.introductionEditView.numOfLetters.text = "(\(introText.count)/50)"
         }
         setNotification()
         bindViewModel()

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageSignOutViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageSignOutViewController.swift
@@ -119,6 +119,7 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.firstReasonView.reasonLabel.text ?? ""
                 case 2:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
@@ -127,6 +128,7 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.secondReasonView.reasonLabel.text ?? ""
                 case 3:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
@@ -135,6 +137,7 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.thirdReasonView.reasonLabel.text ?? ""
                 case 4:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
@@ -143,6 +146,7 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioSelectedButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.fourthReasonView.reasonLabel.text ?? ""
                 case 5:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
@@ -151,6 +155,7 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioSelectedButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.fifthReasonView.reasonLabel.text ?? ""
                 case 6:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
@@ -159,15 +164,16 @@ extension MyPageSignOutViewController {
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.sixthReasonView.radioButton.setImage(radioSelectedButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     signOutReason = self.myView.sixthReasonView.reasonLabel.text ?? ""
-                    
                 case 7:
                     self.myView.firstReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.secondReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.thirdReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fourthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
                     self.myView.fifthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
-                    self.myView.sixthReasonView.radioButton.setImage(radioSelectedButtonImage, for: .normal)
+                    self.myView.sixthReasonView.radioButton.setImage(radioButtonImage, for: .normal)
+                    self.myView.seventhReasonView.radioButton.setImage(radioSelectedButtonImage, for: .normal)
                     signOutReason = self.myView.seventhReasonView.reasonLabel.text ?? ""
                 default:
                     break

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -505,7 +505,7 @@ extension MyPageViewController {
     @objc
     private func goToWriteViewController() {
         let viewController = WriteViewController(viewModel: WriteViewModel(networkProvider: NetworkService()))
-        self.navigationController?.pushViewController(viewController, animated: true)
+        self.navigationController?.pushViewController(viewController, animated: false)
     }
     
     @objc

--- a/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/MyPage/ViewControllers/MyPageViewController.swift
@@ -146,10 +146,13 @@ final class MyPageViewController: UIViewController {
                                                   action: #selector(otherPageHambergerButtonTapped))
             navigationItem.rightBarButtonItem = hambergerButton
         }
+        
+        self.navigationController?.navigationBar.backgroundColor = .donBlack
+        self.navigationController?.navigationBar.barTintColor = .donBlack
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donWhite]
-        self.navigationItem.hidesBackButton = true
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.barTintColor = .clear
+        self.navigationItem.hidesBackButton = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -178,8 +181,6 @@ final class MyPageViewController: UIViewController {
 extension MyPageViewController {
     private func setUI() {
         self.view.backgroundColor = .donBlack
-        self.navigationController?.navigationBar.backgroundColor = .donBlack
-        self.navigationController?.navigationBar.barTintColor = .donBlack
         
         transparentPopupVC.modalPresentationStyle = .overFullScreen
         deletePostPopupVC.modalPresentationStyle = .overFullScreen
@@ -353,7 +354,6 @@ extension MyPageViewController {
                     self.rootView.myPageContentViewController.firstContentButton.isHidden = true
                 } else {
                     self.rootView.myPageContentViewController.noContentLabel.isHidden = false
-                    self.rootView.myPageContentViewController.firstContentButton.isHidden = false
                 }
                 self.rootView.myPageContentViewController.homeCollectionView.reloadData()
             }
@@ -458,9 +458,11 @@ extension MyPageViewController {
         if data.memberId != loadUserData()?.memberId ?? 0 {
             self.rootView.myPageContentViewController.noContentLabel.text = "아직 \(data.nickname)" + StringLiterals.MyPage.myPageNoContentOtherLabel
             self.rootView.myPageCommentViewController.noCommentLabel.text = "아직 \(data.nickname)" + StringLiterals.MyPage.myPageNoCommentOtherLabel
+            self.rootView.myPageContentViewController.firstContentButton.isHidden = true
         } else {
             self.rootView.myPageContentViewController.noContentLabel.text = "\(data.nickname)" + StringLiterals.MyPage.myPageNoContentLabel
             self.rootView.myPageCommentViewController.noCommentLabel.text = StringLiterals.MyPage.myPageNoCommentLabel
+            self.rootView.myPageContentViewController.firstContentButton.isHidden = false
             
             saveUserData(UserInfo(isSocialLogined: true,
                                   isFirstUser: false,

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Cells/PostReplyCollectionViewCell.swift
@@ -42,6 +42,7 @@ final class PostReplyCollectionViewCell: UICollectionViewCell, UICollectionViewR
     
     let profileImageView: UIImageView = {
         let image = UIImageView()
+        image.image = ImageLiterals.Common.imgProfile
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
         image.layer.cornerRadius = 22.adjusted

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/PostReplyTextFieldView.swift
@@ -27,6 +27,7 @@ final class PostReplyTextFieldView: UIView {
     
     let profileImageView: UIImageView = {
         let image = UIImageView()
+        image.image = ImageLiterals.Common.imgProfile
         image.contentMode = .scaleAspectFill
         image.clipsToBounds = true
         image.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyEditorView.swift
@@ -24,13 +24,15 @@ final class WriteReplyEditorView: UIView {
         let imageView = UIImageView()
         imageView.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
         imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = imageView.frame.size.width / 2.adjusted
+        imageView.clipsToBounds = true
         return imageView
     }()
     
     var userNickname: UILabel = {
         let label = UILabel()
         label.text = "\(loadUserData()?.userNickname ?? "")"
-        label.font = UIFont.font(.body1)
+        label.font = UIFont.font(.body3)
         label.textColor = .donBlack
         return label
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Post/Views/WriteReplyView.swift
@@ -191,6 +191,8 @@ extension WriteReplyView: UITextViewDelegate {
         textView.text = String(textView.text.prefix(maxLength))
         
         if textLength == 0 {
+            let value = Double(textLength) / 500
+            circleProgressBar.value = value
             postButton.setTitleColor(.donGray9, for: .normal)
             postButton.backgroundColor = .donGray3
             postButton.isEnabled = false
@@ -206,11 +208,13 @@ extension WriteReplyView: UITextViewDelegate {
                 let value = Double(textLength) / 500
                 circleProgressBar.value = value
                 postButton.isEnabled = true
+                postButton.backgroundColor = .donPrimary
             } else {
                 limitedCircleProgressBar.alpha = 1
                 circleProgressBar.alpha = 0
                 postButton.isEnabled = false
-                
+                postButton.setTitleColor(.donGray9, for: .normal)
+                postButton.backgroundColor = .donGray3
                 impactFeedbackGenerator.impactOccurred()
             }
         }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/ViewControllers/WriteViewController.swift
@@ -58,29 +58,11 @@ final class WriteViewController: UIViewController {
         getAPI()
         bindViewModel()
         
-        self.navigationController?.navigationBar.isHidden = false
-        self.navigationItem.hidesBackButton = false
-        self.tabBarController?.tabBar.isTranslucent = true
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(true)
-        
-        self.navigationController?.navigationBar.isHidden = true
+        self.navigationController?.navigationBar.backgroundColor = .donWhite
+        self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.donBlack]
         self.navigationItem.hidesBackButton = true
-        self.tabBarController?.tabBar.isTranslucent = false
-        NotificationCenter.default.removeObserver(self, name: UITextView.textDidChangeNotification, object: nil)
-
-    }
-}
-
-// MARK: - Extensions
-
-extension WriteViewController {
-    private func setUI() {
-        self.view.backgroundColor = .donWhite
-        self.title = StringLiterals.Write.writeNavigationTitle
-        self.navigationController?.navigationBar.tintColor = .donPrimary
+        self.navigationController?.navigationBar.isHidden = false
+        self.navigationController?.navigationBar.barTintColor = .clear
         
         let backButton = UIBarButtonItem(
             title: StringLiterals.Write.writeNavigationBarButtonItemTitle,
@@ -96,9 +78,22 @@ extension WriteViewController {
         ], for: .normal)
 
         navigationItem.leftBarButtonItem = backButton
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
         
-        self.rootView.writeTextView.userNickname.text = loadUserData()?.userNickname
-        self.rootView.writeTextView.userProfileImage.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
+        NotificationCenter.default.removeObserver(self, name: UITextView.textDidChangeNotification, object: nil)
+
+    }
+}
+
+// MARK: - Extensions
+
+extension WriteViewController {
+    private func setUI() {
+        self.view.backgroundColor = .donWhite
+        self.title = StringLiterals.Write.writeNavigationTitle
         
         if let window = UIApplication.shared.keyWindowInConnectedScenes {
             window.addSubview(banView)

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -20,6 +20,7 @@ final class WriteTextView: UIView {
     
     let userProfileImage: UIImageView = {
         let imageView = UIImageView()
+        imageView.load(url: loadUserData()?.userProfileImage ?? StringLiterals.Network.baseImageURL)
         imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = imageView.frame.size.width / 2
         return imageView
@@ -27,7 +28,8 @@ final class WriteTextView: UIView {
     
     let userNickname: UILabel = {
         let label = UILabel()
-        label.font = UIFont.font(.body1)
+        label.text = loadUserData()?.userNickname ?? ""
+        label.font = UIFont.font(.body3)
         label.textColor = .donBlack
         return label
     }()

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteTextView.swift
@@ -114,7 +114,6 @@ extension WriteTextView {
                 
         if UserDefaults.standard.integer(forKey: "memberGhost") > -85 {
             contentTextView.becomeFirstResponder()
-            NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         }
         // 햅틱 피드백 생성
         impactFeedbackGenerator.prepare()
@@ -148,13 +147,13 @@ extension WriteTextView {
             $0.top.equalTo(userNickname.snp.bottom).offset(4.adjusted)
             $0.leading.equalTo(userNickname.snp.leading)
             $0.trailing.equalToSuperview().inset(16.adjusted)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top)
         }
         
         keyboardToolbarView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56.adjusted)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top)
         }
         
         circleProgressBar.snp.makeConstraints {
@@ -174,26 +173,6 @@ extension WriteTextView {
             $0.trailing.equalToSuperview().inset(16.adjusted)
             $0.width.equalTo(60.adjusted)
             $0.height.equalTo(36.adjusted)
-        }
-    }
-    
-    @objc
-    func keyboardWillShow(_ notification: Notification) {
-        if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardHeight = keyboardFrame.cgRectValue.height
-            
-            contentTextView.snp.remakeConstraints {
-                $0.top.equalTo(userNickname.snp.bottom).offset(4.adjusted)
-                $0.leading.equalTo(userNickname.snp.leading)
-                $0.trailing.equalToSuperview().inset(16.adjusted)
-                $0.bottom.equalTo(-keyboardHeight)
-            }
-            
-            keyboardToolbarView.snp.remakeConstraints {
-                $0.leading.trailing.equalToSuperview()
-                $0.height.equalTo(56.adjusted)
-                $0.bottom.equalTo(-keyboardHeight)
-            }
         }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteView.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Write/Views/WriteView.swift
@@ -49,7 +49,11 @@ extension WriteView {
     }
     
     func setHierarchy() {
-        self.addSubviews(writeTextView, writeCanclePopupView)
+        self.addSubviews(writeTextView)
+        
+        if let window = UIApplication.shared.keyWindowInConnectedScenes {
+            window.addSubviews(writeCanclePopupView)
+        }
     }
     
     func setLayout() {


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 답글 달기 뷰 원형 프로그레스바가 초기화
- 다른 사람 마이페이지 뷰에서 첫 게시글 남기기 버튼 안보이도록 수정
- 오타 수정
- 계정 삭제 사유 뷰에서 기타 버튼 터치 가능하도록 수정
- 댓글 영역 프로필 사진 로드가 안되는 경우 기본 이미지 보이도록 수정
- 글 작성 뷰에서 네비게이션 취소 버튼이 겹치는 버그 해결
- 마이페이지에서 새 글 작성 뷰로 이동 시 네비게이션 바가 검정색으로 변하는 버그 해결

## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 답글이 가끔씩 2개씩 달리는 버그 해결
- 답글 달기 게시글 부분의 프로필 사진 동그랗게 수정
- 위의 2가지 사항은 해결하지 못해서 다음번에 수정하도록 하겠습니다!

## 📟 관련 이슈
- Resolved: #157 
