### PR TITLE
Fix [#162] 로딩뷰 수정

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -87,12 +87,6 @@ final class HomeViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = true
         self.tabBarController?.tabBar.isHidden = false
         
-        if !hasAppearedBefore {
-            hasAppearedBefore = true
-        } else {
-            showLoadingView()
-        }
-        
         bindViewModel()
         setNotification()
     }
@@ -127,18 +121,6 @@ extension HomeViewController {
         
         transparentPopupVC.modalPresentationStyle = .overFullScreen
         deletePostPopupVC.modalPresentationStyle = .overFullScreen
-    }
-    
-    private func showLoadingView() {
-      let loadingView = DontBeLoadingView()
-        print("로딩 시작!")
-      loadingView.show()
-      
-      DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-        loadingView.hide {
-            print("로딩 끝!")
-        }
-      }
     }
     
     private func setHierarchy() {

--- a/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift
@@ -156,6 +156,14 @@ extension DontBeTabBarController: UITabBarControllerDelegate {
             self.tabBar.items?[2].image = ImageLiterals.TabBar.icnNotificationRead
         }
         
+        if beforeIndex == 2 && self.selectedIndex == 0 {
+            showLoadingView()
+        }
+        
+        if beforeIndex == 3 && self.selectedIndex == 0 {
+            showLoadingView()
+        }
+        
         if let selectedViewController = tabBarController.selectedViewController {
             applyFontColorAttributes(to: selectedViewController.tabBarItem, isSelected: true)
         }
@@ -198,5 +206,17 @@ extension DontBeTabBarController: UITabBarControllerDelegate {
             }
         }
         return true
+    }
+}
+
+extension DontBeTabBarController {
+    private func showLoadingView() {
+      let loadingView = DontBeLoadingView()
+      loadingView.show()
+      
+      DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        loadingView.hide {
+        }
+      }
     }
 }

--- a/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift
@@ -214,7 +214,7 @@ extension DontBeTabBarController {
       let loadingView = DontBeLoadingView()
       loadingView.show()
       
-      DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
         loadingView.hide {
         }
       }


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
글쓰기 탭에서 로딩뷰가 뜨는 현상 해결했습니다.
## 💡 참고사항
<!-- 참고할 사항이 있다면 적어주세요. -->

> 로딩뷰 보이는 함수를 추가했습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/c1475db0a76df2b27edada9bf7e7eacbf0262857/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift#L212-L222

> 탭 바 index 번호에 따라 홈 index로 이동하는 알림, 마이의 경우에만 로딩뷰가 보이도록 했습니다.
https://github.com/TeamDon-tBe/Don-tBe-iOS/blob/c1475db0a76df2b27edada9bf7e7eacbf0262857/DontBe-iOS/DontBe-iOS/Presentation/TabBar/DontBeTabBarController.swift#L159-L165

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/TeamDon-tBe/Don-tBe-iOS/assets/107970815/fdb6c0e9-dc63-419d-8f17-2c8cdbdd8a19" width ="250">|

## 📟 관련 이슈
- Resolved: #162 
