### PR TITLE
Fix [#170] 카카오 로그인 시, 회원탈퇴 후 재가입 가능한 오류사항 해결

### DIFF
--- a/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DontBe-iOS/DontBe-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -83,7 +83,7 @@ final class LoginViewModel: NSObject, ViewModelType {
             Task {
                 do {
                     let result = try await self.postSocialLoginAPI(socialPlatform: "KAKAO", accessToken: accessToken, userName: nil)?.data
-                    let isNewUser = result?.isNewUser ?? false
+                    guard let isNewUser = result?.isNewUser else { return }
                     let nickname = result?.nickName ?? ""
                     if !isNewUser && !nickname.isEmpty {
                         self.userInfoPublisher.send(false)


### PR DESCRIPTION
<!--
Prefix [#이슈번호] 작업 설명
예시 : Feat [#33] 마이페이지 뷰 구현
-->

## 👻 *PULL REQUEST*

## 💻 작업한 내용
<!-- `작업한 내용을 적어주세요. -->
- 카카오 로그인 시, 회원탈퇴 후 재가입 가능한 오류사항 해결했습니당!!

## 📟 관련 이슈
- Resolved: #170 
